### PR TITLE
feat: 텔레그램 AI 대화 흐름 안정화 및 알람 경험 개선

### DIFF
--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/port/ChatSaveJob.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/port/ChatSaveJob.kt
@@ -1,9 +1,9 @@
 package com.sleekydz86.tellme.aiserver.aplication.port
 
 data class ChatSaveJob(
-    val userId: String,
-    val userMessage: String,
-    val assistantMessage: String,
-    val mode: String,
+    val userId: String = "",
+    val userMessage: String = "",
+    val assistantMessage: String = "",
+    val mode: String = "",
     val createdAt: Long = System.currentTimeMillis()
 )

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/LocalOllamaCompletionService.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/LocalOllamaCompletionService.kt
@@ -1,0 +1,64 @@
+package com.sleekydz86.tellme.aiserver.aplication.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+
+@Service
+class LocalOllamaCompletionService(
+    @Value("\${spring.ai.ollama.base-url:http://localhost:11434}") baseUrl: String,
+    @param:Value("\${spring.ai.ollama.chat.model:qwen2.5:7b-instruct}") private val model: String,
+    @param:Value("\${spring.ai.ollama.chat.options.temperature:0.7}") private val temperature: Double,
+    @param:Value("\${spring.ai.ollama.chat.options.num_predict:1000}") private val numPredict: Int
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val webClient = WebClient.builder()
+        .baseUrl(baseUrl)
+        .build()
+
+    fun generate(prompt: String): String {
+        val normalizedPrompt = prompt.trim()
+        if (normalizedPrompt.isBlank()) {
+            return ""
+        }
+
+        return runCatching {
+            webClient.post()
+                .uri("/api/generate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(
+                    GenerateRequest(
+                        model = model,
+                        prompt = normalizedPrompt,
+                        stream = false,
+                        options = mapOf(
+                            "temperature" to temperature,
+                            "num_predict" to numPredict
+                        )
+                    )
+                )
+                .retrieve()
+                .bodyToMono(GenerateResponse::class.java)
+                .block()
+                ?.response
+                .orEmpty()
+                .trim()
+        }.onFailure { error ->
+            logger.warn("Local Ollama generate call failed: model={}", model, error)
+        }.getOrDefault("")
+    }
+
+    private data class GenerateRequest(
+        val model: String,
+        val prompt: String,
+        val stream: Boolean,
+        val options: Map<String, Any>
+    )
+
+    private data class GenerateResponse(
+        val response: String? = null
+    )
+}

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/ModeAnswerService.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/ModeAnswerService.kt
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service
 @Service
 class ModeAnswerService(
     private val chatClientProvider: ObjectProvider<ChatClient>,
+    private val localOllamaCompletionService: LocalOllamaCompletionService,
     private val domainEventPublisher: DomainEventPublisher,
     private val redisLockPort: RedisLockPort,
     private val redisQueuePort: RedisQueuePort,
@@ -73,7 +74,13 @@ class ModeAnswerService(
             return chatClient.prompt(mode.toPrompt(message)).call().content()?.trim().orEmpty()
         }
 
-        logger.warn("No ChatClient bean is configured for mode chat. Falling back to template response. mode={}", mode.modeName)
+        logger.warn("No ChatClient bean is configured for mode chat. Trying local Ollama generate API. mode={}", mode.modeName)
+        val ollamaResponse = localOllamaCompletionService.generate(mode.toPrompt(message).contents)
+        if (ollamaResponse.isNotBlank()) {
+            return ollamaResponse
+        }
+
+        logger.warn("Local Ollama generate API was unavailable. Falling back to template response. mode={}", mode.modeName)
         return mode.fallbackReply(message)
     }
 

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/RagAnswerService.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/RagAnswerService.kt
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service
 @Service
 class RagAnswerService(
     private val chatClientProvider: ObjectProvider<ChatClient>,
+    private val localOllamaCompletionService: LocalOllamaCompletionService,
     private val documentService: DocumentService,
     private val documentUsageService: DocumentUsageService,
     private val documentUploadRepository: DocumentUploadRepository
@@ -85,7 +86,13 @@ class RagAnswerService(
             return chatClient.prompt(prompt).call().content()?.trim().orEmpty()
         }
 
-        logger.warn("No ChatClient bean is configured. Falling back to reference-only response.")
+        logger.warn("No ChatClient bean is configured. Trying local Ollama generate API.")
+        val ollamaResponse = localOllamaCompletionService.generate(prompt.contents)
+        if (ollamaResponse.isNotBlank()) {
+            return ollamaResponse
+        }
+
+        logger.warn("Local Ollama generate API was unavailable. Falling back to reference-only response.")
         if (searchResults.isEmpty()) {
             return ""
         }

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/global/config/RedisConfig.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/global/config/RedisConfig.kt
@@ -1,6 +1,7 @@
 package com.sleekydz86.tellme.global.config
 
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
@@ -10,7 +11,9 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @Configuration
-class RedisConfig {
+class RedisConfig(
+    private val objectMapper: ObjectMapper
+) {
 
     @Bean
     fun redisMessageListenerContainer(connectionFactory: RedisConnectionFactory): RedisMessageListenerContainer {
@@ -22,11 +25,12 @@ class RedisConfig {
     @Bean
     fun redisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, Any> {
         val template = RedisTemplate<String, Any>()
+        val serializer = GenericJackson2JsonRedisSerializer(objectMapper)
         template.setConnectionFactory(connectionFactory)
         template.keySerializer = StringRedisSerializer()
-        template.valueSerializer = GenericJackson2JsonRedisSerializer()
+        template.valueSerializer = serializer
         template.hashKeySerializer = StringRedisSerializer()
-        template.hashValueSerializer = GenericJackson2JsonRedisSerializer()
+        template.hashValueSerializer = serializer
         template.afterPropertiesSet()
         return template
     }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/ConversationModeFallbackReplyFactory.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/ConversationModeFallbackReplyFactory.kt
@@ -1,0 +1,38 @@
+package com.sleekydz86.tellme.showme.application.service
+
+import com.sleekydz86.tellme.showme.domain.ConversationMode
+import org.springframework.stereotype.Component
+
+@Component
+class ConversationModeFallbackReplyFactory {
+
+    fun build(mode: ConversationMode, text: String): String {
+        val normalized = text.trim()
+        return when (mode) {
+            ConversationMode.ENG -> buildEnglishReply(normalized)
+            ConversationMode.GOD -> buildGodReply(normalized)
+        }
+    }
+
+    private fun buildEnglishReply(text: String): String =
+        when {
+            text.isBlank() -> "Tell me a little more. I will keep replying in English."
+            text.endsWith("?") -> "That is a thoughtful question. Let us take it one step at a time."
+            else -> "I hear you. Keep going, one sentence at a time, and I will stay with you in English."
+        }
+
+    private fun buildGodReply(text: String): String =
+        when {
+            text.isBlank() ->
+                "\uc791\uc740 \uc228\ube44\ub3c4 \ub2e4\uc2dc \ubc14\ub78c\uc774 \ub429\ub2c8\ub2e4.\n\ucc9c\ucc9c\ud788 \ub9c8\uc74c\uc744 \uac00\ub2e4\ub4ec\uace0 \ub2e4\uc2dc \uc774\uc57c\uae30\ud574 \ubcf4\uc138\uc694."
+
+            text.contains("\ud798\ub4e4") || text.contains("\uc678\ub86d") ->
+                "\uc5b4\ub460\uc744 \uacac\ub514\ub294 \ub9c8\uc74c\uc5d0\ub3c4 \uc544\uce68\uc758 \ube5b\uc740 \ucc3e\uc544\uc635\ub2c8\ub2e4.\n\uc624\ub298\uc740 \uc2a4\uc2a4\ub85c\ub97c \ud0d3\ud558\uc9c0 \ub9d0\uace0, \ud55c \uac78\uc74c\ub9cc \ubc84\ud2f0\uba74 \ucda9\ubd84\ud569\ub2c8\ub2e4."
+
+            text.contains("\ubd88\uc548") || text.contains("\uac71\uc815") ->
+                "\ub9c8\uc74c\uc774 \ud754\ub4e4\ub9b4\uc218\ub85d \ud638\ud761\uc744 \uace0\ub974\uac8c \ud558\uc2ed\uc2dc\uc624.\n\uacb0\ub860\uc744 \uc11c\ub450\ub974\uc9c0 \ub9d0\uace0, \uc624\ub298 \ud560 \uc218 \uc788\ub294 \ud55c \uac00\uc9c0\uc5d0 \uc9d1\uc911\ud574 \ubcf4\uc138\uc694."
+
+            else ->
+                "\ucc9c\ucc9c\ud788 \uac00\ub3c4 \uba48\ucd94\uc9c0 \uc54a\uc73c\uba74 \uc55e\uc73c\ub85c \uac11\ub2c8\ub2e4.\n\uc9c0\uae08\uc758 \uace0\ubbfc\ub3c4 \ud55c \uac78\uc74c\uc529 \ud480\uc5b4\uac00\uba74 \uae38\uc774 \ubcf4\uc77c \uac83\uc785\ub2c8\ub2e4."
+        }
+}

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
@@ -93,7 +93,7 @@ class HandleUpdateService(
         val fromUserName = message.senderDisplayName() ?: fallbackFromName
         val receivedAt = message.date?.let { Instant.ofEpochSecond(it) } ?: Instant.now()
 
-        val saveMono = aiServerTelegram.saveMessage(
+        aiServerTelegram.saveMessage(
             telegramMessageId = messageId,
             chatId = chatId,
             fromUserId = fromUserId,
@@ -106,12 +106,28 @@ class HandleUpdateService(
             } else {
                 historySseService.publishMessageSaved()
             }
-        }
+        }.onErrorResume { e ->
+            log.warn("Telegram message history save error: chatId={}, messageId={}", chatId, messageId, e)
+            Mono.just(false)
+        }.subscribe()
 
         val replyMono = resolveReply(ctx)
+            .onErrorResume { e ->
+                log.warn("Reply generation failed: chatId={}, messageId={}", chatId, messageId, e)
+                Mono.just(
+                    ctx.text?.takeIf { it.isNotBlank() }
+                        ?: "메시지를 받았지만 답변을 만들지 못했습니다. 다시 말씀해 주세요."
+                )
+            }
+            .switchIfEmpty(
+                Mono.just(
+                    ctx.text?.takeIf { it.isNotBlank() }
+                        ?: "메시지를 받았지만 답변을 만들지 못했습니다. 다시 말씀해 주세요."
+                )
+            )
 
-        return saveMono
-            .then(replyMono.flatMap { reply -> telegramApi.sendMessage(chatId, reply)!! })
+        return replyMono
+            .flatMap { reply -> telegramApi.sendMessage(chatId, reply)!! }
             .then()
     }
 
@@ -133,16 +149,42 @@ class HandleUpdateService(
         }
 
         val text = ctx.text.orEmpty()
+        log.info("Routing text to active conversation mode: chatId={}, mode={}, text={}", chatId, activeMode.aiMode, text)
         if (isConversationExitText(text)) {
             conversationModeStore.clear(chatId)
             return Mono.just("${activeMode.label}를 종료했어요. 이제 원래 대화로 돌아왔습니다.")
         }
 
         return aiServerModeChat.chat(chatId.toString(), text, activeMode)
+            .onErrorResume { e ->
+                log.warn("Mode chat fallback activated: chatId={}, mode={}", chatId, activeMode.aiMode, e)
+                Mono.just(buildModeFallbackReply(activeMode, text))
+            }
     }
 
     private fun isConversationExitText(text: String?): Boolean =
         text?.trim()?.equals(EXIT_KEYWORD, ignoreCase = true) == true
+
+    private fun buildModeFallbackReply(mode: com.sleekydz86.tellme.showme.domain.ConversationMode, text: String): String {
+        val normalized = text.trim()
+        return when (mode) {
+            com.sleekydz86.tellme.showme.domain.ConversationMode.ENG -> when {
+                normalized.isBlank() -> "Tell me a little more. I will keep replying in English."
+                normalized.endsWith("?") -> "That is a thoughtful question. Let us take it one step at a time."
+                else -> "I hear you. Keep going, one sentence at a time, and I will stay with you in English."
+            }
+
+            com.sleekydz86.tellme.showme.domain.ConversationMode.GOD -> when {
+                normalized.isBlank() -> "작은 빛도 어둠을 밀어냅니다.\n천천히 마음을 가다듬고 다시 이야기해 보세요."
+                normalized.contains("힘들") || normalized.contains("외롭") ->
+                    "상처를 견디는 마음에도 내일의 빛은 찾아옵니다.\n오늘의 아픔이 당신의 전부는 아니니, 한 걸음만 더 버텨 보세요."
+                normalized.contains("불안") || normalized.contains("걱정") ->
+                    "마음이 흔들릴수록 호흡을 고르게 하십시오.\n결론을 서두르지 말고, 오늘 할 수 있는 한 가지에 집중해 보세요."
+                else ->
+                    "천천히 가도 멈추지 않으면 앞으로 갑니다.\n지금의 고민도 한 걸음씩 풀어가면 길이 보일 것입니다."
+            }
+        }
+    }
 
     private fun handleDocument(chatId: Long, message: TelegramUpdate.Message): Mono<Void> {
         val document = message.document ?: return Mono.empty()

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 import java.nio.file.Files
+import java.time.Duration
 import java.time.Instant
 
 @Service
@@ -139,11 +140,10 @@ class HandleUpdateService(
         }
 
         val chatId = ctx.chatId ?: return echoHandler?.handle(ctx) ?: Mono.empty()
-        if (timeAlarmService.hasPendingSetup(chatId)) {
+        val activeMode = conversationModeStore.get(chatId)
+        if (activeMode == null && timeAlarmService.hasPendingSetup(chatId)) {
             return Mono.just(timeAlarmService.continueSetup(chatId, ctx.text.orEmpty()))
         }
-
-        val activeMode = conversationModeStore.get(chatId)
         if (activeMode == null) {
             return echoHandler?.handle(ctx) ?: Mono.empty()
         }
@@ -156,6 +156,7 @@ class HandleUpdateService(
         }
 
         return aiServerModeChat.chat(chatId.toString(), text, activeMode)
+            .timeout(MODE_REPLY_TIMEOUT, Mono.just(buildModeFallbackReply(activeMode, text)))
             .onErrorResume { e ->
                 log.warn("Mode chat fallback activated: chatId={}, mode={}", chatId, activeMode.aiMode, e)
                 Mono.just(buildModeFallbackReply(activeMode, text))
@@ -318,6 +319,7 @@ class HandleUpdateService(
 
     companion object {
         private const val EXIT_KEYWORD = "bye"
+        private val MODE_REPLY_TIMEOUT: Duration = Duration.ofSeconds(3)
         private const val FALLBACK_MESSAGE = "텍스트나 파일(문서/사진/음성/동영상)을 보내주세요."
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
@@ -30,6 +30,7 @@ class HandleUpdateService(
     private val aiServerUpload: AiServerUploadPort,
     private val aiServerTelegram: AiServerTelegramPort,
     private val aiServerModeChat: AiServerModeChatPort,
+    private val fallbackReplyFactory: ConversationModeFallbackReplyFactory,
     private val conversationModeStore: TelegramConversationModeStore,
     private val timeAlarmService: TimeAlarmService,
     private val historySseService: HistorySseService,
@@ -156,10 +157,10 @@ class HandleUpdateService(
         }
 
         return aiServerModeChat.chat(chatId.toString(), text, activeMode)
-            .timeout(MODE_REPLY_TIMEOUT, Mono.just(buildModeFallbackReply(activeMode, text)))
+            .timeout(MODE_REPLY_TIMEOUT, Mono.just(fallbackReplyFactory.build(activeMode, text)))
             .onErrorResume { e ->
                 log.warn("Mode chat fallback activated: chatId={}, mode={}", chatId, activeMode.aiMode, e)
-                Mono.just(buildModeFallbackReply(activeMode, text))
+                Mono.just(fallbackReplyFactory.build(activeMode, text))
             }
     }
 

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PollingSchedulerService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PollingSchedulerService.kt
@@ -7,8 +7,11 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 import kotlin.math.max
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 
 @Service
@@ -16,19 +19,40 @@ import kotlin.math.max
 @ConditionalOnProperty(name = ["telegram.polling.enabled"], havingValue = "true", matchIfMissing = true)
 class PollingSchedulerService(
     private val telegramApi: TelegramApiPort,
-    private val handleUpdateService: HandleUpdateService
+    private val handleUpdateService: HandleUpdateService,
+    private val pollingGuard: TelegramPollingGuard
 ) {
     private val log = LoggerFactory.getLogger(PollingSchedulerService::class.java)
     private var nextOffset: Long = 0
+    private val pollInProgress = AtomicBoolean(false)
+    private val suspendedUntilEpochMs = AtomicLong(0)
 
     @Scheduled(fixedDelayString = "\${telegram.polling.fixed-delay-ms:500}")
     fun poll() {
         if (telegramApi.isTokenMissing) return
-        val mono = telegramApi.getUpdates(nextOffset) ?: return
+        if (System.currentTimeMillis() < suspendedUntilEpochMs.get()) return
+        if (!pollInProgress.compareAndSet(false, true)) return
+        if (!pollingGuard.tryAcquire(SCHEDULER_OWNER)) {
+            pollInProgress.set(false)
+            return
+        }
+        val mono = telegramApi.getUpdates(nextOffset)
+        if (mono == null) {
+            pollInProgress.set(false)
+            pollingGuard.release(SCHEDULER_OWNER)
+            return
+        }
         mono.flatMap { update: TelegramUpdate -> processResult(update) }
+            .doFinally {
+                pollInProgress.set(false)
+                pollingGuard.release(SCHEDULER_OWNER)
+            }
             .subscribe(
-                { offset: Long -> nextOffset = offset },
-                { err -> log.error("Poll error", err) }
+                { offset: Long ->
+                    nextOffset = offset
+                    suspendedUntilEpochMs.set(0)
+                },
+                { err -> handlePollError(err) }
             )
     }
 
@@ -51,5 +75,56 @@ class PollingSchedulerService(
             }
         }
         return Mono.just(maxId)
+    }
+
+    private fun handlePollError(err: Throwable) {
+        if (err is WebClientResponseException && err.statusCode.value() == 409) {
+            suspendPollingOnConflict(err)
+            return
+        }
+        log.error("Poll error", err)
+    }
+
+    private fun suspendPollingOnConflict(err: WebClientResponseException) {
+        val description = extractConflictDescription(err.responseBodyAsString)
+        val normalized = description.lowercase()
+        val backoffMs = when {
+            normalized.contains("webhook") -> WEBHOOK_CONFLICT_BACKOFF_MS
+            normalized.contains("terminated by other getupdates request") ||
+                normalized.contains("only one bot instance") -> MULTIPLE_POLLER_CONFLICT_BACKOFF_MS
+            else -> DEFAULT_CONFLICT_BACKOFF_MS
+        }
+
+        suspendedUntilEpochMs.set(System.currentTimeMillis() + backoffMs)
+
+        val summary = when {
+            normalized.contains("webhook") ->
+                "Telegram webhook is active, so scheduled polling will pause briefly."
+            normalized.contains("terminated by other getupdates request") ||
+                normalized.contains("only one bot instance") ->
+                "Another getUpdates consumer is already running, so scheduled polling will pause briefly."
+            else ->
+                "Telegram getUpdates returned 409 Conflict, so scheduled polling will pause briefly."
+        }
+
+        log.warn("{} Retry in {} ms. {}", summary, backoffMs, description)
+    }
+
+    private fun extractConflictDescription(responseBody: String?): String {
+        val body = responseBody.orEmpty()
+        val description = Regex("\"description\"\\s*:\\s*\"([^\"]+)\"")
+            .find(body)
+            ?.groupValues
+            ?.getOrNull(1)
+
+        return description?.takeIf { it.isNotBlank() }
+            ?: body.ifBlank { "409 Conflict from Telegram getUpdates" }
+    }
+
+    companion object {
+        private const val DEFAULT_CONFLICT_BACKOFF_MS = 15_000L
+        private const val MULTIPLE_POLLER_CONFLICT_BACKOFF_MS = 10_000L
+        private const val WEBHOOK_CONFLICT_BACKOFF_MS = 60_000L
+        private const val SCHEDULER_OWNER = "scheduler"
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PollingSchedulerService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PollingSchedulerService.kt
@@ -8,11 +8,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import reactor.core.publisher.Mono
-import kotlin.math.max
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
-
+import kotlin.math.max
 
 @Service
 @RequiredArgsConstructor
@@ -24,65 +21,52 @@ class PollingSchedulerService(
 ) {
     private val log = LoggerFactory.getLogger(PollingSchedulerService::class.java)
     private var nextOffset: Long = 0
-    private val pollInProgress = AtomicBoolean(false)
     private val suspendedUntilEpochMs = AtomicLong(0)
 
     @Scheduled(fixedDelayString = "\${telegram.polling.fixed-delay-ms:500}")
     fun poll() {
         if (telegramApi.isTokenMissing) return
         if (System.currentTimeMillis() < suspendedUntilEpochMs.get()) return
-        if (!pollInProgress.compareAndSet(false, true)) return
-        if (!pollingGuard.tryAcquire(SCHEDULER_OWNER)) {
-            pollInProgress.set(false)
-            return
-        }
-        val mono = telegramApi.getUpdates(nextOffset)
-        if (mono == null) {
-            pollInProgress.set(false)
-            pollingGuard.release(SCHEDULER_OWNER)
-            return
-        }
-        mono.flatMap { update: TelegramUpdate -> processResult(update) }
-            .doFinally {
-                pollInProgress.set(false)
-                pollingGuard.release(SCHEDULER_OWNER)
+        if (!pollingGuard.tryAcquire(SCHEDULER_OWNER)) return
+
+        try {
+            val update = telegramApi.getUpdates(nextOffset)?.block() ?: return
+            nextOffset = processResult(update)
+            suspendedUntilEpochMs.set(0)
+        } catch (err: WebClientResponseException) {
+            if (err.statusCode.value() == 409) {
+                suspendPollingOnConflict(err)
+            } else {
+                log.error("Poll error", err)
             }
-            .subscribe(
-                { offset: Long ->
-                    nextOffset = offset
-                    suspendedUntilEpochMs.set(0)
-                },
-                { err -> handlePollError(err) }
-            )
+        } catch (err: Exception) {
+            log.error("Poll error", err)
+        } finally {
+            pollingGuard.release(SCHEDULER_OWNER)
+        }
     }
 
-    private fun processResult(update: TelegramUpdate): Mono<Long> {
+    private fun processResult(update: TelegramUpdate): Long {
         val resultList = update.result
         if (resultList.isNullOrEmpty()) {
-            val offset: Long = nextOffset
-            return Mono.just(offset)
+            return nextOffset
         }
-        var maxId: Long = nextOffset
-        for (ur in resultList) {
-            if (ur?.updateId != null) {
-                maxId = max(maxId, ur.updateId + 1)
-            }
-            ur?.incomingMessage()?.let { msg ->
-                handleUpdateService.handle(msg).subscribe(
-                    { },
-                    { e -> log.warn("Handle message error", e) }
-                )
-            }
-        }
-        return Mono.just(maxId)
-    }
 
-    private fun handlePollError(err: Throwable) {
-        if (err is WebClientResponseException && err.statusCode.value() == 409) {
-            suspendPollingOnConflict(err)
-            return
+        var maxId = nextOffset
+        for (updateResult in resultList) {
+            val updateId = updateResult?.updateId
+            if (updateId != null) {
+                maxId = max(maxId, updateId + 1)
+            }
+
+            val message = updateResult?.incomingMessage() ?: continue
+            try {
+                handleUpdateService.handle(message).block()
+            } catch (e: Exception) {
+                log.warn("Handle message error: updateId={}", updateId, e)
+            }
         }
-        log.error("Poll error", err)
+        return maxId
     }
 
     private fun suspendPollingOnConflict(err: WebClientResponseException) {

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/TelegramConversationModeStore.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/TelegramConversationModeStore.kt
@@ -1,30 +1,69 @@
 package com.sleekydz86.tellme.showme.application.service
 
 import com.sleekydz86.tellme.showme.domain.ConversationMode
+import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Component
 import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
 
 @Component
 class TelegramConversationModeStore(
     private val redisTemplate: StringRedisTemplate
 ) {
+    private val log = LoggerFactory.getLogger(TelegramConversationModeStore::class.java)
+    private val fallbackModes = ConcurrentHashMap<Long, StoredMode>()
+
     fun get(chatId: Long): ConversationMode? {
-        val raw = redisTemplate.opsForValue().get(key(chatId))
-        return ConversationMode.fromAiMode(raw)
+        val redisMode = runCatching {
+            redisTemplate.opsForValue().get(key(chatId))
+        }.onFailure { e ->
+            log.warn("Failed to read conversation mode from Redis: chatId={}", chatId, e)
+        }.getOrNull()?.let { ConversationMode.fromAiMode(it) }
+
+        if (redisMode != null) {
+            fallbackModes[chatId] = StoredMode(redisMode, Instant.now().plus(MODE_TTL))
+            return redisMode
+        }
+
+        val fallback = fallbackModes[chatId]
+        if (fallback == null) {
+            return null
+        }
+        if (fallback.expiresAt.isBefore(Instant.now())) {
+            fallbackModes.remove(chatId)
+            return null
+        }
+        return fallback.mode
     }
 
     fun activate(chatId: Long, mode: ConversationMode) {
-        redisTemplate.opsForValue().set(key(chatId), mode.aiMode, MODE_TTL)
+        fallbackModes[chatId] = StoredMode(mode, Instant.now().plus(MODE_TTL))
+        runCatching {
+            redisTemplate.opsForValue().set(key(chatId), mode.aiMode, MODE_TTL)
+        }.onFailure { e ->
+            log.warn("Failed to store conversation mode in Redis: chatId={}, mode={}", chatId, mode.aiMode, e)
+        }
     }
 
     fun clear(chatId: Long): ConversationMode? {
         val mode = get(chatId)
-        redisTemplate.delete(key(chatId))
+        fallbackModes.remove(chatId)
+        runCatching {
+            redisTemplate.delete(key(chatId))
+        }.onFailure { e ->
+            log.warn("Failed to clear conversation mode in Redis: chatId={}", chatId, e)
+        }
         return mode
     }
 
     private fun key(chatId: Long): String = "telegram:conversation-mode:$chatId"
+
+    private data class StoredMode(
+        val mode: ConversationMode,
+        val expiresAt: Instant
+    )
 
     companion object {
         private val MODE_TTL: Duration = Duration.ofHours(24)

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/TelegramPollingGuard.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/TelegramPollingGuard.kt
@@ -1,0 +1,17 @@
+package com.sleekydz86.tellme.showme.application.service
+
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicReference
+
+@Component
+class TelegramPollingGuard {
+    private val activeOwner = AtomicReference<String?>(null)
+
+    fun tryAcquire(owner: String): Boolean = activeOwner.compareAndSet(null, owner)
+
+    fun release(owner: String) {
+        activeOwner.compareAndSet(owner, null)
+    }
+
+    fun currentOwner(): String? = activeOwner.get()
+}

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/EngCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/EngCommandHandler.kt
@@ -1,18 +1,21 @@
 package com.sleekydz86.tellme.showme.application.service.handler
 
 import com.sleekydz86.tellme.showme.application.port.AiServerModeChatPort
+import com.sleekydz86.tellme.showme.application.service.ConversationModeFallbackReplyFactory
 import com.sleekydz86.tellme.showme.application.service.TelegramConversationModeStore
 import com.sleekydz86.tellme.showme.application.service.TimeAlarmService
 import com.sleekydz86.tellme.showme.domain.ConversationMode
 import com.sleekydz86.tellme.showme.domain.MessageContext
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Mono
+import java.time.Duration
 
 @Component
 class EngCommandHandler(
     private val conversationModeStore: TelegramConversationModeStore,
     private val timeAlarmService: TimeAlarmService,
-    private val aiServerModeChat: AiServerModeChatPort
+    private val aiServerModeChat: AiServerModeChatPort,
+    private val fallbackReplyFactory: ConversationModeFallbackReplyFactory
 ) : CommandHandler {
 
     override fun handle(ctx: MessageContext?): Mono<String> {
@@ -22,21 +25,24 @@ class EngCommandHandler(
 
         val prompt = ctx.commandArgument().takeUnless { it.isNullOrBlank() } ?: DEFAULT_PROMPT
         val introSuffix = if (ctx.isPrivateChat()) "" else GROUP_PRIVACY_HINT
+        val fallbackReply = fallbackReplyFactory.build(ConversationMode.ENG, prompt)
 
         return aiServerModeChat.chat(chatId.toString(), prompt, ConversationMode.ENG)
-            .map { if (it.isBlank()) EMPTY_REPLY_MESSAGE else it }
+            .timeout(INTRO_REPLY_TIMEOUT, Mono.just(fallbackReply))
+            .map { it.trim() }
+            .map { if (it.isBlank()) fallbackReply else it }
+            .onErrorResume { Mono.just(fallbackReply) }
             .map { "$it\n\n$INTRO_MESSAGE$introSuffix" }
     }
 
     companion object {
+        private val INTRO_REPLY_TIMEOUT: Duration = Duration.ofSeconds(3)
         private const val CHAT_NOT_FOUND_MESSAGE =
             "\ucc44\ud305 \uc815\ubcf4\ub97c \ucc3e\uc9c0 \ubabb\ud588\uc2b5\ub2c8\ub2e4."
         private const val GROUP_PRIVACY_HINT =
             "\n\n\ucc38\uace0: \uadf8\ub8f9/\uc288\ud37c\uadf8\ub8f9\uc5d0\uc11c Telegram privacy mode\uac00 \ucf1c\uc838 \uc788\uc73c\uba74 \uc77c\ubc18 \uba54\uc2dc\uc9c0\ub97c \ubabb \ubc1b\uc744 \uc218 \uc788\uc2b5\ub2c8\ub2e4. 1:1 \ucc44\ud305\uc744 \uc0ac\uc6a9\ud558\uac70\ub098 BotFather /setprivacy\ub97c Disable\ub85c \ubc14\uafd4 \uc8fc\uc138\uc694."
         private const val INTRO_MESSAGE =
             "\uc601\uc5b4 \ub300\ud654 \ubaa8\ub4dc\ub97c \uc2dc\uc791\ud588\uc5b4\uc694. \uc774\uc81c \uc77c\ubc18 \uba54\uc2dc\uc9c0\ub97c \ubcf4\ub0b4\uba74 AiServer\uac00 \uc601\uc5b4\ub85c \ub2f5\ud569\ub2c8\ub2e4. \uc885\ub8cc\ub294 bye \ub610\ub294 /end \ub97c \uc785\ub825\ud574 \uc8fc\uc138\uc694."
-        private const val EMPTY_REPLY_MESSAGE =
-            "\uc601\uc5b4 \ubaa8\ub4dc \uc751\ub2f5\uc774 \ube44\uc5b4 \uc788\uc2b5\ub2c8\ub2e4."
         private const val DEFAULT_PROMPT = "Say one short warm English greeting to start our conversation."
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/EngCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/EngCommandHandler.kt
@@ -17,19 +17,18 @@ class EngCommandHandler(
         val chatId = ctx?.chatId ?: return Mono.just(CHAT_NOT_FOUND_MESSAGE)
         conversationModeStore.activate(chatId, ConversationMode.ENG)
 
-        val prompt = ctx.commandArgument()
-        if (prompt.isNullOrBlank()) {
-            return Mono.just(INTRO_MESSAGE)
-        }
+        val prompt = ctx.commandArgument().takeUnless { it.isNullOrBlank() } ?: DEFAULT_PROMPT
 
         return aiServerModeChat.chat(chatId.toString(), prompt, ConversationMode.ENG)
             .map { if (it.isBlank()) EMPTY_REPLY_MESSAGE else it }
+            .map { "$it\n\n$INTRO_MESSAGE" }
     }
 
     companion object {
         private const val CHAT_NOT_FOUND_MESSAGE = "채팅 정보를 찾지 못했습니다."
         private const val INTRO_MESSAGE =
             "영어 대화 모드를 시작했어요. 이제 일반 메시지를 보내면 AiServer가 영어로 답합니다. 종료는 bye 또는 /end 를 입력해 주세요."
-        private const val EMPTY_REPLY_MESSAGE = "영어 대화 응답이 비어 있습니다."
+        private const val EMPTY_REPLY_MESSAGE = "영어 모드 응답이 비어 있습니다."
+        private const val DEFAULT_PROMPT = "Say one short warm English greeting to start our conversation."
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/EngCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/EngCommandHandler.kt
@@ -2,6 +2,7 @@ package com.sleekydz86.tellme.showme.application.service.handler
 
 import com.sleekydz86.tellme.showme.application.port.AiServerModeChatPort
 import com.sleekydz86.tellme.showme.application.service.TelegramConversationModeStore
+import com.sleekydz86.tellme.showme.application.service.TimeAlarmService
 import com.sleekydz86.tellme.showme.domain.ConversationMode
 import com.sleekydz86.tellme.showme.domain.MessageContext
 import org.springframework.stereotype.Component
@@ -10,25 +11,32 @@ import reactor.core.publisher.Mono
 @Component
 class EngCommandHandler(
     private val conversationModeStore: TelegramConversationModeStore,
+    private val timeAlarmService: TimeAlarmService,
     private val aiServerModeChat: AiServerModeChatPort
 ) : CommandHandler {
 
     override fun handle(ctx: MessageContext?): Mono<String> {
         val chatId = ctx?.chatId ?: return Mono.just(CHAT_NOT_FOUND_MESSAGE)
+        timeAlarmService.cancelSetup(chatId)
         conversationModeStore.activate(chatId, ConversationMode.ENG)
 
         val prompt = ctx.commandArgument().takeUnless { it.isNullOrBlank() } ?: DEFAULT_PROMPT
+        val introSuffix = if (ctx.isPrivateChat()) "" else GROUP_PRIVACY_HINT
 
         return aiServerModeChat.chat(chatId.toString(), prompt, ConversationMode.ENG)
             .map { if (it.isBlank()) EMPTY_REPLY_MESSAGE else it }
-            .map { "$it\n\n$INTRO_MESSAGE" }
+            .map { "$it\n\n$INTRO_MESSAGE$introSuffix" }
     }
 
     companion object {
-        private const val CHAT_NOT_FOUND_MESSAGE = "채팅 정보를 찾지 못했습니다."
+        private const val CHAT_NOT_FOUND_MESSAGE =
+            "\ucc44\ud305 \uc815\ubcf4\ub97c \ucc3e\uc9c0 \ubabb\ud588\uc2b5\ub2c8\ub2e4."
+        private const val GROUP_PRIVACY_HINT =
+            "\n\n\ucc38\uace0: \uadf8\ub8f9/\uc288\ud37c\uadf8\ub8f9\uc5d0\uc11c Telegram privacy mode\uac00 \ucf1c\uc838 \uc788\uc73c\uba74 \uc77c\ubc18 \uba54\uc2dc\uc9c0\ub97c \ubabb \ubc1b\uc744 \uc218 \uc788\uc2b5\ub2c8\ub2e4. 1:1 \ucc44\ud305\uc744 \uc0ac\uc6a9\ud558\uac70\ub098 BotFather /setprivacy\ub97c Disable\ub85c \ubc14\uafd4 \uc8fc\uc138\uc694."
         private const val INTRO_MESSAGE =
-            "영어 대화 모드를 시작했어요. 이제 일반 메시지를 보내면 AiServer가 영어로 답합니다. 종료는 bye 또는 /end 를 입력해 주세요."
-        private const val EMPTY_REPLY_MESSAGE = "영어 모드 응답이 비어 있습니다."
+            "\uc601\uc5b4 \ub300\ud654 \ubaa8\ub4dc\ub97c \uc2dc\uc791\ud588\uc5b4\uc694. \uc774\uc81c \uc77c\ubc18 \uba54\uc2dc\uc9c0\ub97c \ubcf4\ub0b4\uba74 AiServer\uac00 \uc601\uc5b4\ub85c \ub2f5\ud569\ub2c8\ub2e4. \uc885\ub8cc\ub294 bye \ub610\ub294 /end \ub97c \uc785\ub825\ud574 \uc8fc\uc138\uc694."
+        private const val EMPTY_REPLY_MESSAGE =
+            "\uc601\uc5b4 \ubaa8\ub4dc \uc751\ub2f5\uc774 \ube44\uc5b4 \uc788\uc2b5\ub2c8\ub2e4."
         private const val DEFAULT_PROMPT = "Say one short warm English greeting to start our conversation."
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/GodCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/GodCommandHandler.kt
@@ -2,6 +2,7 @@ package com.sleekydz86.tellme.showme.application.service.handler
 
 import com.sleekydz86.tellme.showme.application.port.AiServerModeChatPort
 import com.sleekydz86.tellme.showme.application.service.TelegramConversationModeStore
+import com.sleekydz86.tellme.showme.application.service.TimeAlarmService
 import com.sleekydz86.tellme.showme.domain.ConversationMode
 import com.sleekydz86.tellme.showme.domain.MessageContext
 import org.springframework.stereotype.Component
@@ -10,25 +11,33 @@ import reactor.core.publisher.Mono
 @Component
 class GodCommandHandler(
     private val conversationModeStore: TelegramConversationModeStore,
+    private val timeAlarmService: TimeAlarmService,
     private val aiServerModeChat: AiServerModeChatPort
 ) : CommandHandler {
 
     override fun handle(ctx: MessageContext?): Mono<String> {
         val chatId = ctx?.chatId ?: return Mono.just(CHAT_NOT_FOUND_MESSAGE)
+        timeAlarmService.cancelSetup(chatId)
         conversationModeStore.activate(chatId, ConversationMode.GOD)
 
         val prompt = ctx.commandArgument().takeUnless { it.isNullOrBlank() } ?: DEFAULT_PROMPT
+        val introSuffix = if (ctx.isPrivateChat()) "" else GROUP_PRIVACY_HINT
 
         return aiServerModeChat.chat(chatId.toString(), prompt, ConversationMode.GOD)
             .map { if (it.isBlank()) EMPTY_REPLY_MESSAGE else it }
-            .map { "$it\n\n$INTRO_MESSAGE" }
+            .map { "$it\n\n$INTRO_MESSAGE$introSuffix" }
     }
 
     companion object {
-        private const val CHAT_NOT_FOUND_MESSAGE = "채팅 정보를 찾지 못했습니다."
+        private const val CHAT_NOT_FOUND_MESSAGE =
+            "\ucc44\ud305 \uc815\ubcf4\ub97c \ucc3e\uc9c0 \ubabb\ud588\uc2b5\ub2c8\ub2e4."
+        private const val GROUP_PRIVACY_HINT =
+            "\n\n\ucc38\uace0: \uadf8\ub8f9/\uc288\ud37c\uadf8\ub8f9\uc5d0\uc11c Telegram privacy mode\uac00 \ucf1c\uc838 \uc788\uc73c\uba74 \uc77c\ubc18 \uba54\uc2dc\uc9c0\ub97c \ubabb \ubc1b\uc744 \uc218 \uc788\uc2b5\ub2c8\ub2e4. 1:1 \ucc44\ud305\uc744 \uc0ac\uc6a9\ud558\uac70\ub098 BotFather /setprivacy\ub97c Disable\ub85c \ubc14\uafd4 \uc8fc\uc138\uc694."
         private const val INTRO_MESSAGE =
-            "명언 대화 모드를 시작했어요. 이제 일반 메시지를 보내면 AiServer가 짧은 명언이나 격언 느낌으로 답합니다. 종료는 bye 또는 /end 를 입력해 주세요."
-        private const val EMPTY_REPLY_MESSAGE = "명언 모드 응답이 비어 있습니다."
-        private const val DEFAULT_PROMPT = "오늘 나에게 필요한 짧은 명언이나 격언 한마디를 들려줘."
+            "\uba85\uc5b8 \ub300\ud654 \ubaa8\ub4dc\ub97c \uc2dc\uc791\ud588\uc5b4\uc694. \uc774\uc81c \uc77c\ubc18 \uba54\uc2dc\uc9c0\ub97c \ubcf4\ub0b4\uba74 AiServer\uac00 \uc9e7\uc740 \uba85\uc5b8\uc774\ub098 \uaca9\uc5b8 \ub290\ub08c\uc73c\ub85c \ub2f5\ud569\ub2c8\ub2e4. \uc885\ub8cc\ub294 bye \ub610\ub294 /end \ub97c \uc785\ub825\ud574 \uc8fc\uc138\uc694."
+        private const val EMPTY_REPLY_MESSAGE =
+            "\uba85\uc5b8 \ubaa8\ub4dc \uc751\ub2f5\uc774 \ube44\uc5b4 \uc788\uc2b5\ub2c8\ub2e4."
+        private const val DEFAULT_PROMPT =
+            "\uc624\ub298 \ub098\uc5d0\uac8c \ud544\uc694\ud55c \uc9e7\uc740 \uba85\uc5b8\uc774\ub098 \uaca9\uc5b8 \ud55c\ub9c8\ub514\ub97c \uc54c\ub824\uc918"
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/GodCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/GodCommandHandler.kt
@@ -1,18 +1,21 @@
 package com.sleekydz86.tellme.showme.application.service.handler
 
 import com.sleekydz86.tellme.showme.application.port.AiServerModeChatPort
+import com.sleekydz86.tellme.showme.application.service.ConversationModeFallbackReplyFactory
 import com.sleekydz86.tellme.showme.application.service.TelegramConversationModeStore
 import com.sleekydz86.tellme.showme.application.service.TimeAlarmService
 import com.sleekydz86.tellme.showme.domain.ConversationMode
 import com.sleekydz86.tellme.showme.domain.MessageContext
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Mono
+import java.time.Duration
 
 @Component
 class GodCommandHandler(
     private val conversationModeStore: TelegramConversationModeStore,
     private val timeAlarmService: TimeAlarmService,
-    private val aiServerModeChat: AiServerModeChatPort
+    private val aiServerModeChat: AiServerModeChatPort,
+    private val fallbackReplyFactory: ConversationModeFallbackReplyFactory
 ) : CommandHandler {
 
     override fun handle(ctx: MessageContext?): Mono<String> {
@@ -22,21 +25,24 @@ class GodCommandHandler(
 
         val prompt = ctx.commandArgument().takeUnless { it.isNullOrBlank() } ?: DEFAULT_PROMPT
         val introSuffix = if (ctx.isPrivateChat()) "" else GROUP_PRIVACY_HINT
+        val fallbackReply = fallbackReplyFactory.build(ConversationMode.GOD, prompt)
 
         return aiServerModeChat.chat(chatId.toString(), prompt, ConversationMode.GOD)
-            .map { if (it.isBlank()) EMPTY_REPLY_MESSAGE else it }
+            .timeout(INTRO_REPLY_TIMEOUT, Mono.just(fallbackReply))
+            .map { it.trim() }
+            .map { if (it.isBlank()) fallbackReply else it }
+            .onErrorResume { Mono.just(fallbackReply) }
             .map { "$it\n\n$INTRO_MESSAGE$introSuffix" }
     }
 
     companion object {
+        private val INTRO_REPLY_TIMEOUT: Duration = Duration.ofSeconds(3)
         private const val CHAT_NOT_FOUND_MESSAGE =
             "\ucc44\ud305 \uc815\ubcf4\ub97c \ucc3e\uc9c0 \ubabb\ud588\uc2b5\ub2c8\ub2e4."
         private const val GROUP_PRIVACY_HINT =
             "\n\n\ucc38\uace0: \uadf8\ub8f9/\uc288\ud37c\uadf8\ub8f9\uc5d0\uc11c Telegram privacy mode\uac00 \ucf1c\uc838 \uc788\uc73c\uba74 \uc77c\ubc18 \uba54\uc2dc\uc9c0\ub97c \ubabb \ubc1b\uc744 \uc218 \uc788\uc2b5\ub2c8\ub2e4. 1:1 \ucc44\ud305\uc744 \uc0ac\uc6a9\ud558\uac70\ub098 BotFather /setprivacy\ub97c Disable\ub85c \ubc14\uafd4 \uc8fc\uc138\uc694."
         private const val INTRO_MESSAGE =
             "\uba85\uc5b8 \ub300\ud654 \ubaa8\ub4dc\ub97c \uc2dc\uc791\ud588\uc5b4\uc694. \uc774\uc81c \uc77c\ubc18 \uba54\uc2dc\uc9c0\ub97c \ubcf4\ub0b4\uba74 AiServer\uac00 \uc9e7\uc740 \uba85\uc5b8\uc774\ub098 \uaca9\uc5b8 \ub290\ub08c\uc73c\ub85c \ub2f5\ud569\ub2c8\ub2e4. \uc885\ub8cc\ub294 bye \ub610\ub294 /end \ub97c \uc785\ub825\ud574 \uc8fc\uc138\uc694."
-        private const val EMPTY_REPLY_MESSAGE =
-            "\uba85\uc5b8 \ubaa8\ub4dc \uc751\ub2f5\uc774 \ube44\uc5b4 \uc788\uc2b5\ub2c8\ub2e4."
         private const val DEFAULT_PROMPT =
             "\uc624\ub298 \ub098\uc5d0\uac8c \ud544\uc694\ud55c \uc9e7\uc740 \uba85\uc5b8\uc774\ub098 \uaca9\uc5b8 \ud55c\ub9c8\ub514\ub97c \uc54c\ub824\uc918"
     }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/GodCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/GodCommandHandler.kt
@@ -17,19 +17,18 @@ class GodCommandHandler(
         val chatId = ctx?.chatId ?: return Mono.just(CHAT_NOT_FOUND_MESSAGE)
         conversationModeStore.activate(chatId, ConversationMode.GOD)
 
-        val prompt = ctx.commandArgument()
-        if (prompt.isNullOrBlank()) {
-            return Mono.just(INTRO_MESSAGE)
-        }
+        val prompt = ctx.commandArgument().takeUnless { it.isNullOrBlank() } ?: DEFAULT_PROMPT
 
         return aiServerModeChat.chat(chatId.toString(), prompt, ConversationMode.GOD)
             .map { if (it.isBlank()) EMPTY_REPLY_MESSAGE else it }
+            .map { "$it\n\n$INTRO_MESSAGE" }
     }
 
     companion object {
         private const val CHAT_NOT_FOUND_MESSAGE = "채팅 정보를 찾지 못했습니다."
         private const val INTRO_MESSAGE =
             "명언 대화 모드를 시작했어요. 이제 일반 메시지를 보내면 AiServer가 짧은 명언이나 격언 느낌으로 답합니다. 종료는 bye 또는 /end 를 입력해 주세요."
-        private const val EMPTY_REPLY_MESSAGE = "명언 대화 응답이 비어 있습니다."
+        private const val EMPTY_REPLY_MESSAGE = "명언 모드 응답이 비어 있습니다."
+        private const val DEFAULT_PROMPT = "오늘 나에게 필요한 짧은 명언이나 격언 한마디를 들려줘."
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/usecase/PollUpdatesUseCase.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/usecase/PollUpdatesUseCase.kt
@@ -2,18 +2,18 @@ package com.sleekydz86.tellme.showme.application.service.usecase
 
 import com.sleekydz86.tellme.showme.application.port.TelegramApiPort
 import com.sleekydz86.tellme.showme.application.service.HandleUpdateService
+import com.sleekydz86.tellme.showme.application.service.TelegramPollingGuard
 import com.sleekydz86.tellme.showme.domain.dto.TelegramUpdate
 import org.slf4j.LoggerFactory
-import org.springframework.web.reactive.function.client.WebClientResponseException
-import tools.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Service
+import tools.jackson.databind.ObjectMapper
 import java.util.concurrent.atomic.AtomicLong
-
 
 @Service
 class PollUpdatesUseCase(
     private val telegramApi: TelegramApiPort,
-    private val handleUpdateService: HandleUpdateService
+    private val handleUpdateService: HandleUpdateService,
+    private val pollingGuard: TelegramPollingGuard
 ) {
     private val log = LoggerFactory.getLogger(PollUpdatesUseCase::class.java)
     private val lastUpdateId = AtomicLong(0)
@@ -21,66 +21,77 @@ class PollUpdatesUseCase(
 
     fun pollAndProcess(): String? {
         if (telegramApi.isTokenMissing) {
-            return jsonResult("봇 토큰이 설정되지 않았습니다.")
+            return jsonResult("텔레그램 토큰이 설정되지 않았습니다.")
         }
+
         val webhookUrl = telegramApi.getWebhookInfo()?.block()?.result?.url?.takeIf { it.isNotBlank() }
         if (webhookUrl != null) {
             return jsonResultWebhookActive()
         }
-        var result = jsonResult("신규 메시지 없음")
-        for (i in 0..<MAX_ATTEMPTS) {
-            val offset = if (lastUpdateId.get() > 0) lastUpdateId.get() + 1 else null
-            val update: TelegramUpdate?
-            try {
-                update = telegramApi.getUpdates(offset)?.block()
-            } catch (e: Exception) {
-                if (e is WebClientResponseException && e.statusCode.value() == 409) {
-                    return jsonResultWebhookActive()
-                }
-                log.warn("getUpdates error", e)
-                return jsonResult("오류")
-            }
-            if (update == null || update.result == null || update.result.isEmpty()) {
-                if (sleepInterruptible()) {
-                    return jsonResult("오류")
-                }
-                continue
-            }
 
-            val processedTexts = mutableListOf<String>()
-            for (ur in update.result!!) {
-                val u = ur ?: continue
-                val incomingMessage = u.incomingMessage()
-                if (u.updateId != null && u.updateId > lastUpdateId.get() && incomingMessage != null) {
+        if (!pollingGuard.tryAcquire(MANUAL_OWNER)) {
+            return jsonResultPollingBusy()
+        }
+
+        return try {
+            var result = jsonResult("신규 메시지가 없습니다.")
+            for (attempt in 0 until MAX_ATTEMPTS) {
+                val offset = if (lastUpdateId.get() > 0) lastUpdateId.get() + 1 else null
+                val update = try {
+                    telegramApi.getUpdates(offset)?.block()
+                } catch (e: Exception) {
+                    log.warn("getUpdates error", e)
+                    return jsonResult("오류가 발생했습니다.")
+                }
+
+                if (update == null || update.result.isNullOrEmpty()) {
+                    if (sleepInterruptible()) {
+                        return jsonResult("오류가 발생했습니다.")
+                    }
+                    continue
+                }
+
+                val processedTexts = mutableListOf<String>()
+                for (updateResult in update.result!!) {
+                    val incomingMessage = updateResult?.incomingMessage() ?: continue
+                    val updateId = updateResult.updateId ?: continue
+                    if (updateId <= lastUpdateId.get()) {
+                        continue
+                    }
+
                     handleUpdateService.handle(incomingMessage).block()
                     incomingMessage.text?.let { processedTexts.add(it) }
-                    lastUpdateId.set(u.updateId)
+                    lastUpdateId.set(updateId)
+                }
+
+                if (processedTexts.isNotEmpty()) {
+                    result = jsonResult("수신한 메시지(${processedTexts.joinToString(", ")})를 처리했습니다.")
+                    break
+                }
+
+                if (sleepInterruptible()) {
+                    return jsonResult("오류가 발생했습니다.")
                 }
             }
-            if (processedTexts.isNotEmpty()) {
-                result = jsonResult("수신된 메시지(" + processedTexts.joinToString(", ") + ")를 처리함.")
-                break
-            }
-            if (sleepInterruptible()) {
-                return jsonResult("오류")
-            }
+            result
+        } finally {
+            pollingGuard.release(MANUAL_OWNER)
         }
-        return result
     }
 
     private fun sleepInterruptible(): Boolean {
-        try {
+        return try {
             Thread.sleep(SLEEP_MS.toLong())
-            return false
+            false
         } catch (e: InterruptedException) {
             Thread.currentThread().interrupt()
-            return true
+            true
         }
     }
 
     private fun jsonResult(message: String?): String? {
         return try {
-            objectMapper.writeValueAsString(mapOf<String, String>("result" to (message ?: "")))
+            objectMapper.writeValueAsString(mapOf("result" to (message ?: "")))
         } catch (e: tools.jackson.core.JacksonException) {
             ERROR_JSON
         }
@@ -99,10 +110,28 @@ class PollUpdatesUseCase(
         }
     }
 
+    private fun jsonResultPollingBusy(): String {
+        val message = when (pollingGuard.currentOwner()) {
+            SCHEDULER_OWNER -> POLLING_BUSY_BY_SCHEDULER_MESSAGE
+            MANUAL_OWNER -> POLLING_BUSY_BY_MANUAL_MESSAGE
+            else -> POLLING_BUSY_GENERIC_MESSAGE
+        }
+        return jsonResult(message) ?: ERROR_JSON
+    }
+
     companion object {
         private const val MAX_ATTEMPTS = 10
         private const val SLEEP_MS = 5000
-        private const val ERROR_JSON = "{\"result\" : \"오류\"}"
-        private const val WEBHOOK_ACTIVE_MESSAGE = "웹후크 사용 중에는 getUpdates(폴링)를 사용할 수 없습니다. 웹후크 페이지에서 삭제 후 이용하세요."
+        private const val ERROR_JSON = "{\"result\":\"오류가 발생했습니다.\"}"
+        private const val WEBHOOK_ACTIVE_MESSAGE =
+            "웹훅 사용 중에는 getUpdates(폴링)를 사용할 수 없습니다. 웹훅 페이지에서 삭제 후 이용하세요."
+        private const val POLLING_BUSY_BY_SCHEDULER_MESSAGE =
+            "자동 텔레그램 polling이 이미 실행 중입니다. /get-updates 화면과 자동 polling 중 하나만 사용해 주세요."
+        private const val POLLING_BUSY_BY_MANUAL_MESSAGE =
+            "다른 getUpdates 요청이 이미 진행 중입니다. 잠시 후 다시 시도해 주세요."
+        private const val POLLING_BUSY_GENERIC_MESSAGE =
+            "다른 getUpdates 요청과 충돌했습니다. 잠시 후 다시 시도해 주세요."
+        private const val MANUAL_OWNER = "manual"
+        private const val SCHEDULER_OWNER = "scheduler"
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/MessageContext.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/MessageContext.kt
@@ -5,8 +5,11 @@ import com.sleekydz86.tellme.showme.domain.dto.TelegramUpdate
 data class MessageContext(
     val chatId: Long? = null,
     val text: String? = null,
-    val firstName: String? = null
+    val firstName: String? = null,
+    val chatType: String? = null
 ) {
+    fun isPrivateChat(): Boolean = chatType.equals("private", ignoreCase = true)
+
     fun commandArgument(): String? {
         val trimmed = text?.trim().orEmpty()
         if (trimmed.isBlank()) return null
@@ -25,7 +28,8 @@ data class MessageContext(
             val chatId = message.chat?.id
             val text = message.text?.trim() ?: ""
             val firstName = message.from?.firstName ?: "사용자"
-            return MessageContext(chatId = chatId, text = text, firstName = firstName)
+            val chatType = message.chat?.type
+            return MessageContext(chatId = chatId, text = text, firstName = firstName, chatType = chatType)
         }
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/adapter/AiServerWebClientAdapter.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/adapter/AiServerWebClientAdapter.kt
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 import java.net.URLEncoder
+import java.time.Duration
 import java.time.Instant
 
 @Component
@@ -121,6 +122,7 @@ class AiServerWebClientAdapter(
             .bodyValue(body)
             .retrieve()
             .bodyToMono(String::class.java)
+            .timeout(AI_SERVER_RESPONSE_TIMEOUT)
             .map { it.trim() }
             .defaultIfEmpty("검색 결과가 비어 있습니다.")
             .onErrorResume { e ->
@@ -141,6 +143,7 @@ class AiServerWebClientAdapter(
             .bodyValue(body)
             .retrieve()
             .bodyToMono(String::class.java)
+            .timeout(AI_SERVER_RESPONSE_TIMEOUT)
             .map { it.trim() }
             .map { if (it.isBlank()) "${mode.label} 응답이 비어 있습니다." else it }
             .onErrorResume { e ->
@@ -194,5 +197,9 @@ class AiServerWebClientAdapter(
             params.add("search=${URLEncoder.encode(search, Charsets.UTF_8)}")
         }
         return "$path?${params.joinToString("&")}"
+    }
+
+    companion object {
+        private val AI_SERVER_RESPONSE_TIMEOUT: Duration = Duration.ofSeconds(10)
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/adapter/AiServerWebClientAdapter.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/adapter/AiServerWebClientAdapter.kt
@@ -124,10 +124,10 @@ class AiServerWebClientAdapter(
             .bodyToMono(String::class.java)
             .timeout(AI_SERVER_RESPONSE_TIMEOUT)
             .map { it.trim() }
-            .defaultIfEmpty("검색 결과가 비어 있습니다.")
+            .defaultIfEmpty(EMPTY_SEARCH_RESULT_MESSAGE)
             .onErrorResume { e ->
                 log.warn("Failed to search in AiServer: userId={}", userId, e)
-                Mono.just("문서 검색 중 오류가 발생했습니다. AiServer 상태를 확인해 주세요.")
+                Mono.just(SEARCH_ERROR_MESSAGE)
             }
     }
 
@@ -145,10 +145,10 @@ class AiServerWebClientAdapter(
             .bodyToMono(String::class.java)
             .timeout(AI_SERVER_RESPONSE_TIMEOUT)
             .map { it.trim() }
-            .map { if (it.isBlank()) "${mode.label} 응답이 비어 있습니다." else it }
-            .onErrorResume { e ->
+            .filter { it.isNotBlank() }
+            .switchIfEmpty(Mono.error(IllegalStateException("AiServer mode reply is blank: mode=${mode.aiMode}")))
+            .doOnError { e ->
                 log.warn("Failed to chat with AiServer mode: userId={}, mode={}", userId, mode.aiMode, e)
-                Mono.just("AiServer ${mode.label} 응답 중 오류가 발생했습니다. AiServer 상태를 확인해 주세요.")
             }
     }
 
@@ -201,5 +201,9 @@ class AiServerWebClientAdapter(
 
     companion object {
         private val AI_SERVER_RESPONSE_TIMEOUT: Duration = Duration.ofSeconds(10)
+        private const val EMPTY_SEARCH_RESULT_MESSAGE =
+            "\uac80\uc0c9 \uacb0\uacfc\uac00 \ube44\uc5b4 \uc788\uc2b5\ub2c8\ub2e4."
+        private const val SEARCH_ERROR_MESSAGE =
+            "\ubb38\uc11c \uac80\uc0c9 \uc911 \uc624\ub958\uac00 \ubc1c\uc0dd\ud588\uc2b5\ub2c8\ub2e4. AiServer \uc0c1\ud0dc\ub97c \ud655\uc778\ud574 \uc8fc\uc138\uc694."
     }
 }


### PR DESCRIPTION
## 요약
- 텔레그램 polling, AI 대화 모드, AiServer fallback 흐름을 안정화했습니다.
- 1:1 채팅과 프론트 입력이 그룹 채팅과 같은 파서/대화 흐름을 타도록 맞췄습니다.
- 알람 중지 기능과 사용자 지정 알람 문구를 추가했습니다.

## 변경 사항
- 중복 `getUpdates` 호출을 방지하고 `409 conflict` 로그 폭주를 완화했습니다.
- 텔레그램 메시지 저장과 답장 전송을 분리해 응답 지연 영향을 줄였습니다.
- `/god`, `/eng` 대화 모드를 Redis + 메모리 fallback으로 안정화했습니다.
- AiServer 지연/오프라인 시 fallback 답장을 제공하도록 보강했습니다.
- `ChatClient`가 없을 때 로컬 Ollama HTTP fallback을 사용하도록 AiServer를 개선했습니다.
- 1:1 채팅에서는 일반 메시지도 AI 대화로 처리하고, `god`, `eng`, `search` 같은 bare alias도 인식하도록 했습니다.
- 프론트 입력을 backend shared parser(`chat_input.do`)로 연결해 Telegram과 동일한 입력 흐름을 사용하도록 했습니다.
- `/time` 알람 설정에서 자연어 시간/간격 입력을 보강했습니다.
- `/alarmstop`을 추가하고 `/end`가 활성 알람까지 중지하도록 수정했습니다.
- 알람 문구를 사용자 입력으로 저장하고 실제 알림 본문에 반영하도록 했습니다.
