### PR TITLE
fix: 일반 질문 AI 응답 흐름 정리 및 의도치 않은 모드 전환 방지

### DIFF
--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/RagAnswerService.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/RagAnswerService.kt
@@ -27,7 +27,7 @@ class RagAnswerService(
     ): String {
         val normalizedQuestion = question.trim()
         if (normalizedQuestion.isBlank()) {
-            return "검색어를 입력해 주세요. 예: /search 휴가 규정"
+            return "질문을 입력해 주세요."
         }
 
         val searchResults = if (useKnowledgeBase) documentService.doSearch(normalizedQuestion) else emptyList()
@@ -51,12 +51,18 @@ class RagAnswerService(
 
         val prompt = if (searchResults.isNotEmpty()) {
             createRagPrompt(normalizedQuestion, searchResults)
+        } else if (!useKnowledgeBase) {
+            createGeneralPrompt(normalizedQuestion)
         } else {
             Prompt(normalizedQuestion)
         }
 
         val content = generateResponse(prompt, searchResults)
         if (content.isNotBlank()) {
+            if (shouldPreferKorean(normalizedQuestion) && looksEnglishOnly(content)) {
+                logger.warn("General answer language mismatch detected. Falling back to Korean reply.")
+                return buildKoreanFallback(normalizedQuestion)
+            }
             return content
         }
 
@@ -80,6 +86,12 @@ class RagAnswerService(
         return Prompt(promptContent)
     }
 
+    private fun createGeneralPrompt(question: String): Prompt {
+        val promptContent = GENERAL_PROMPT_TEMPLATE
+            .replace("{question}", question)
+        return Prompt(promptContent)
+    }
+
     private fun generateResponse(prompt: Prompt, searchResults: List<Document>): String {
         val chatClient = chatClientProvider.ifAvailable
         if (chatClient != null) {
@@ -98,7 +110,7 @@ class RagAnswerService(
         }
 
         return buildString {
-            appendLine("업로드된 문서를 기준으로 찾은 내용입니다.")
+            appendLine("업로드한 문서를 기준으로 찾은 내용입니다.")
             appendLine()
             append(
                 searchResults.take(3).joinToString("\n\n") { doc ->
@@ -109,10 +121,43 @@ class RagAnswerService(
         }.trim()
     }
 
+    private fun shouldPreferKorean(question: String): Boolean =
+        question.any { ch -> ch in '\uAC00'..'\uD7A3' || ch in '\u3131'..'\u318E' }
+
+    private fun looksEnglishOnly(content: String): Boolean {
+        val hasHangul = content.any { ch -> ch in '\uAC00'..'\uD7A3' || ch in '\u3131'..'\u318E' }
+        val hasLatin = content.any { it in 'A'..'Z' || it in 'a'..'z' }
+        return hasLatin && !hasHangul
+    }
+
+    private fun buildKoreanFallback(question: String): String =
+        when {
+            question.endsWith("?") || question.contains("왜") || question.contains("어떻게") ->
+                "좋은 질문이에요. 핵심부터 차근차근 같이 풀어볼게요."
+
+            question.contains("힘들") || question.contains("외롭") || question.contains("슬프") ->
+                "많이 버거우셨겠어요. 지금 가장 크게 걸리는 부분부터 편하게 말해 주세요."
+
+            else ->
+                "계속 말씀해 주세요. 질문하신 내용에 맞춰 이어서 도와드릴게요."
+        }
+
     companion object {
+        private const val GENERAL_PROMPT_TEMPLATE = """
+        You are a helpful chat assistant.
+        Default to Korean unless the user clearly writes mostly in English or explicitly asks for English.
+        If the user writes in Korean, answer only in Korean.
+        Do not switch to English just because a few English words appear in the message.
+        Keep the reply concise, direct, and conversational.
+
+        User message:
+        {question}
+        """
+
         private const val RAG_PROMPT_TEMPLATE = """
         아래 참고 자료를 우선 사용해서 사용자 질문에 답하세요.
         참고 자료에 없는 내용은 추측하지 말고, 문서에서 찾지 못했다고 명확히 말하세요.
+        답변 언어는 사용자의 질문 언어를 따르세요. 한국어 질문이면 한국어로만 답하세요.
 
         참고 자료:
         {context}
@@ -122,9 +167,9 @@ class RagAnswerService(
         """
 
         private const val NO_DOCUMENTS_MESSAGE =
-            "아직 업로드된 문서가 없습니다. http://localhost:3000/channel 에서 문서를 업로드한 뒤 다시 /search 해 주세요."
+            "아직 업로드한 문서가 없습니다. http://localhost:3000/channel 에서 문서를 업로드한 뒤 다시 /search 해 주세요."
 
         private const val NO_MATCH_MESSAGE =
-            "업로드된 문서에서 관련 내용을 찾지 못했습니다. 다른 키워드로 다시 /search 해 주세요."
+            "업로드한 문서에서 관련 내용을 찾지 못했습니다. 다른 키워드로 다시 /search 해 주세요."
     }
 }

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/presentation/controller/ChatController.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/presentation/controller/ChatController.kt
@@ -44,6 +44,16 @@ class ChatController(
         )
     }
 
+    @PostMapping("/reply", produces = [MediaType.TEXT_PLAIN_VALUE])
+    fun chatReply(@RequestBody body: ChatSendRequest): String {
+        return ragAnswerService.answer(
+            currentUserName = body.currentUserName,
+            question = body.message,
+            useKnowledgeBase = body.useKnowledgeBase,
+            strictKnowledgeBase = false
+        )
+    }
+
     @PostMapping("/mode", produces = [MediaType.TEXT_PLAIN_VALUE])
     fun chatMode(@RequestBody body: ModeChatRequest): String {
         return modeAnswerService.answer(

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/port/AiServerReplyPort.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/port/AiServerReplyPort.kt
@@ -1,0 +1,7 @@
+package com.sleekydz86.tellme.showme.application.port
+
+import reactor.core.publisher.Mono
+
+interface AiServerReplyPort {
+    fun reply(userId: String, message: String): Mono<String>
+}

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/FrontendChatSessionIdCodec.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/FrontendChatSessionIdCodec.kt
@@ -1,0 +1,20 @@
+package com.sleekydz86.tellme.showme.application.service
+
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.util.zip.CRC32
+
+@Component
+class FrontendChatSessionIdCodec {
+
+    fun toChatId(sessionId: String): Long {
+        val normalized = sessionId.trim().ifBlank { "frontend-anonymous" }
+        val crc32 = CRC32()
+        crc32.update(normalized.toByteArray(StandardCharsets.UTF_8))
+        return FRONTEND_CHAT_ID_BASE + crc32.value
+    }
+
+    companion object {
+        private const val FRONTEND_CHAT_ID_BASE = 8_000_000_000_000_000_000L
+    }
+}

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
@@ -161,24 +161,21 @@ class HandleUpdateService(
             return Mono.just(timeAlarmService.continueSetup(chatId, ctx.text.orEmpty()))
         }
 
-        if (activeMode == null && ctx.isPrivateChat()) {
+        if (activeMode == null) {
             val text = ctx.text.orEmpty()
             log.info(
-                "Routing private chat text to general AI reply: chatId={}, source={}, text={}",
+                "Routing general chat text to AI reply: chatId={}, chatType={}, source={}, text={}",
                 chatId,
+                ctx.chatType,
                 ctx.inputSource,
                 text
             )
             return aiServerReply.reply(chatId.toString(), text)
                 .timeout(PRIVATE_CHAT_REPLY_TIMEOUT, Mono.just(privateChatReplyFallbackFactory.build(text)))
                 .onErrorResume { e ->
-                    log.warn("Private chat fallback activated: chatId={}, source={}", chatId, ctx.inputSource, e)
+                    log.warn("General chat fallback activated: chatId={}, chatType={}, source={}", chatId, ctx.chatType, ctx.inputSource, e)
                     Mono.just(privateChatReplyFallbackFactory.build(text))
                 }
-        }
-
-        if (activeMode == null) {
-            return echoHandler?.handle(ctx) ?: Mono.empty()
         }
 
         val text = ctx.text.orEmpty()
@@ -332,8 +329,8 @@ class HandleUpdateService(
     companion object {
         private const val EXIT_KEYWORD = "bye"
         private val MODE_REPLY_TIMEOUT: Duration = Duration.ofSeconds(3)
-        private val PRIVATE_CHAT_REPLY_TIMEOUT: Duration = Duration.ofSeconds(3)
-        private const val DEFAULT_REPLY_MESSAGE = "I received the message but could not build a reply. Please try again."
-        private const val FALLBACK_MESSAGE = "Please send text or a file (document/photo/voice/video)."
+        private val PRIVATE_CHAT_REPLY_TIMEOUT: Duration = Duration.ofSeconds(8)
+        private const val DEFAULT_REPLY_MESSAGE = "답변을 만드는 데 문제가 있었어요. 한 번만 다시 말씀해 주세요."
+        private const val FALLBACK_MESSAGE = "텍스트나 파일(문서/사진/음성/동영상)을 보내 주세요."
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
@@ -1,12 +1,14 @@
 package com.sleekydz86.tellme.showme.application.service
 
 import com.sleekydz86.tellme.showme.application.port.AiServerModeChatPort
+import com.sleekydz86.tellme.showme.application.port.AiServerReplyPort
 import com.sleekydz86.tellme.showme.application.port.AiServerTelegramPort
 import com.sleekydz86.tellme.showme.application.port.AiServerUploadPort
 import com.sleekydz86.tellme.showme.application.port.TelegramApiPort
 import com.sleekydz86.tellme.showme.application.service.handler.CommandHandler
-import com.sleekydz86.tellme.showme.application.service.handler.EndCommandHandler
+import com.sleekydz86.tellme.showme.application.service.handler.AlarmStopCommandHandler
 import com.sleekydz86.tellme.showme.application.service.handler.EchoCommandHandler
+import com.sleekydz86.tellme.showme.application.service.handler.EndCommandHandler
 import com.sleekydz86.tellme.showme.application.service.handler.EngCommandHandler
 import com.sleekydz86.tellme.showme.application.service.handler.GodCommandHandler
 import com.sleekydz86.tellme.showme.application.service.handler.HelpCommandHandler
@@ -30,7 +32,9 @@ class HandleUpdateService(
     private val aiServerUpload: AiServerUploadPort,
     private val aiServerTelegram: AiServerTelegramPort,
     private val aiServerModeChat: AiServerModeChatPort,
+    private val aiServerReply: AiServerReplyPort,
     private val fallbackReplyFactory: ConversationModeFallbackReplyFactory,
+    private val privateChatReplyFallbackFactory: PrivateChatReplyFallbackFactory,
     private val conversationModeStore: TelegramConversationModeStore,
     private val timeAlarmService: TimeAlarmService,
     private val historySseService: HistorySseService,
@@ -40,12 +44,13 @@ class HandleUpdateService(
     lottoHandler: LottoCommandHandler?,
     godHandler: GodCommandHandler?,
     engHandler: EngCommandHandler?,
+    alarmStopHandler: AlarmStopCommandHandler?,
     endHandler: EndCommandHandler?,
     searchHandler: SearchCommandHandler?,
     echoHandler: EchoCommandHandler?
 ) {
     private val log = LoggerFactory.getLogger(HandleUpdateService::class.java)
-    private val echoHandler: CommandHandler?
+    private val echoHandler: CommandHandler? = echoHandler
 
     private val commandHandlers: Map<BotCommand, CommandHandler?> = mapOf(
         BotCommand.START to startHandler,
@@ -54,13 +59,10 @@ class HandleUpdateService(
         BotCommand.LOTTO to lottoHandler,
         BotCommand.GOD to godHandler,
         BotCommand.ENG to engHandler,
+        BotCommand.ALARM_STOP to alarmStopHandler,
         BotCommand.END to endHandler,
         BotCommand.SEARCH to searchHandler
     )
-
-    init {
-        this.echoHandler = echoHandler
-    }
 
     fun handle(message: TelegramUpdate.Message): Mono<Void> {
         val chatId = message.chat?.id ?: return Mono.empty()
@@ -84,13 +86,29 @@ class HandleUpdateService(
         return telegramApi.sendMessage(chatId, FALLBACK_MESSAGE)!!.then()
     }
 
+    fun replyForContext(ctx: MessageContext): Mono<String> {
+        val defaultReply = ctx.text?.takeIf { it.isNotBlank() } ?: DEFAULT_REPLY_MESSAGE
+        return resolveReply(ctx)
+            .onErrorResume { e ->
+                log.warn(
+                    "Reply generation failed: chatId={}, source={}, text={}",
+                    ctx.chatId,
+                    ctx.inputSource,
+                    ctx.text,
+                    e
+                )
+                Mono.just(defaultReply)
+            }
+            .switchIfEmpty(Mono.just(defaultReply))
+    }
+
     private fun handleText(chatId: Long, message: TelegramUpdate.Message): Mono<Void> {
         val ctx = MessageContext.from(message) ?: return Mono.empty()
         val messageId = message.messageId ?: 0L
         val fallbackFromId = message.from?.id ?: 0L
         val fallbackFromName = message.from?.firstName?.takeIf { it.isNotBlank() }
             ?: message.from?.username?.takeIf { it.isNotBlank() }
-            ?: "사용자"
+            ?: "User"
         val fromUserId = message.senderId() ?: fallbackFromId
         val fromUserName = message.senderDisplayName() ?: fallbackFromName
         val receivedAt = message.date?.let { Instant.ofEpochSecond(it) } ?: Instant.now()
@@ -113,38 +131,52 @@ class HandleUpdateService(
             Mono.just(false)
         }.subscribe()
 
-        val replyMono = resolveReply(ctx)
-            .onErrorResume { e ->
-                log.warn("Reply generation failed: chatId={}, messageId={}", chatId, messageId, e)
-                Mono.just(
-                    ctx.text?.takeIf { it.isNotBlank() }
-                        ?: "메시지를 받았지만 답변을 만들지 못했습니다. 다시 말씀해 주세요."
-                )
-            }
-            .switchIfEmpty(
-                Mono.just(
-                    ctx.text?.takeIf { it.isNotBlank() }
-                        ?: "메시지를 받았지만 답변을 만들지 못했습니다. 다시 말씀해 주세요."
-                )
-            )
-
-        return replyMono
+        return replyForContext(ctx)
             .flatMap { reply -> telegramApi.sendMessage(chatId, reply)!! }
             .then()
     }
 
     private fun resolveReply(ctx: MessageContext): Mono<String> {
-        val command = BotCommand.from(ctx.text)
+        val allowBareAliases = ctx.isPrivateChat() || ctx.isFrontend()
+        val command = BotCommand.from(ctx.text, allowBareAliases = allowBareAliases)
         if (command != null) {
+            if (command == BotCommand.TIME && !ctx.supportsAlarmSetup()) {
+                return Mono.just(
+                    timeAlarmService.buildCurrentTimeMessage() +
+                        "\nFrontend chat does not store Telegram alarms. Use /time in Telegram to continue alarm setup."
+                )
+            }
             val handler = commandHandlers[command] ?: return Mono.empty()
             return handler.handle(ctx) ?: Mono.empty()
         }
 
         val chatId = ctx.chatId ?: return echoHandler?.handle(ctx) ?: Mono.empty()
         val activeMode = conversationModeStore.get(chatId)
+
         if (activeMode == null && timeAlarmService.hasPendingSetup(chatId)) {
+            if (!ctx.supportsAlarmSetup()) {
+                timeAlarmService.cancelSetup(chatId)
+                return Mono.just("Frontend chat does not continue Telegram alarm setup. Use /time in Telegram instead.")
+            }
             return Mono.just(timeAlarmService.continueSetup(chatId, ctx.text.orEmpty()))
         }
+
+        if (activeMode == null && ctx.isPrivateChat()) {
+            val text = ctx.text.orEmpty()
+            log.info(
+                "Routing private chat text to general AI reply: chatId={}, source={}, text={}",
+                chatId,
+                ctx.inputSource,
+                text
+            )
+            return aiServerReply.reply(chatId.toString(), text)
+                .timeout(PRIVATE_CHAT_REPLY_TIMEOUT, Mono.just(privateChatReplyFallbackFactory.build(text)))
+                .onErrorResume { e ->
+                    log.warn("Private chat fallback activated: chatId={}, source={}", chatId, ctx.inputSource, e)
+                    Mono.just(privateChatReplyFallbackFactory.build(text))
+                }
+        }
+
         if (activeMode == null) {
             return echoHandler?.handle(ctx) ?: Mono.empty()
         }
@@ -153,7 +185,7 @@ class HandleUpdateService(
         log.info("Routing text to active conversation mode: chatId={}, mode={}, text={}", chatId, activeMode.aiMode, text)
         if (isConversationExitText(text)) {
             conversationModeStore.clear(chatId)
-            return Mono.just("${activeMode.label}를 종료했어요. 이제 원래 대화로 돌아왔습니다.")
+            return Mono.just("${activeMode.label} ended. Returning to normal conversation.")
         }
 
         return aiServerModeChat.chat(chatId.toString(), text, activeMode)
@@ -167,30 +199,9 @@ class HandleUpdateService(
     private fun isConversationExitText(text: String?): Boolean =
         text?.trim()?.equals(EXIT_KEYWORD, ignoreCase = true) == true
 
-    private fun buildModeFallbackReply(mode: com.sleekydz86.tellme.showme.domain.ConversationMode, text: String): String {
-        val normalized = text.trim()
-        return when (mode) {
-            com.sleekydz86.tellme.showme.domain.ConversationMode.ENG -> when {
-                normalized.isBlank() -> "Tell me a little more. I will keep replying in English."
-                normalized.endsWith("?") -> "That is a thoughtful question. Let us take it one step at a time."
-                else -> "I hear you. Keep going, one sentence at a time, and I will stay with you in English."
-            }
-
-            com.sleekydz86.tellme.showme.domain.ConversationMode.GOD -> when {
-                normalized.isBlank() -> "작은 빛도 어둠을 밀어냅니다.\n천천히 마음을 가다듬고 다시 이야기해 보세요."
-                normalized.contains("힘들") || normalized.contains("외롭") ->
-                    "상처를 견디는 마음에도 내일의 빛은 찾아옵니다.\n오늘의 아픔이 당신의 전부는 아니니, 한 걸음만 더 버텨 보세요."
-                normalized.contains("불안") || normalized.contains("걱정") ->
-                    "마음이 흔들릴수록 호흡을 고르게 하십시오.\n결론을 서두르지 말고, 오늘 할 수 있는 한 가지에 집중해 보세요."
-                else ->
-                    "천천히 가도 멈추지 않으면 앞으로 갑니다.\n지금의 고민도 한 걸음씩 풀어가면 길이 보일 것입니다."
-            }
-        }
-    }
-
     private fun handleDocument(chatId: Long, message: TelegramUpdate.Message): Mono<Void> {
         val document = message.document ?: return Mono.empty()
-        val fileId = document.fileId
+        val fileId = document.fileId ?: return Mono.empty()
         val fileName = document.fileName ?: "document"
         log.info("Document received: fileId={}, fileName={}, size={}", fileId, fileName, document.fileSize)
 
@@ -199,15 +210,15 @@ class HandleUpdateService(
                 val bytes = try {
                     Files.readAllBytes(localPath)
                 } catch (e: Exception) {
-                    log.warn("document read error", e)
-                    return@flatMap telegramApi.sendMessage(chatId, "파일 읽기 오류: ${e.message}")!!.then()
+                    log.warn("Document read error", e)
+                    return@flatMap telegramApi.sendMessage(chatId, "Failed to read document: ${e.message}")!!.then()
                 }
 
                 val telegramMessageId = message.messageId ?: 0L
                 val fromUserName = message.senderDisplayName()
                     ?: message.from?.firstName?.takeIf { it.isNotBlank() }
                     ?: message.from?.username?.takeIf { it.isNotBlank() }
-                    ?: "사용자"
+                    ?: "User"
 
                 aiServerUpload.upload(
                     bytes = bytes,
@@ -230,22 +241,22 @@ class HandleUpdateService(
                     }
                 }.flatMap { saved ->
                     val reply = if (saved) {
-                        "파일을 받았습니다.\n이름: $fileName\n크기: ${document.fileSize ?: 0} bytes"
+                        "Document received.\nName: $fileName\nSize: ${document.fileSize ?: 0} bytes"
                     } else {
-                        "파일 저장 중 오류가 발생했습니다."
+                        "An error occurred while saving the document."
                     }
                     telegramApi.sendMessage(chatId, reply)!!
                 }
             }
-            .onErrorResume { e -> telegramApi.sendMessage(chatId, "파일 저장 중 오류: ${e.message}")!! }
+            .onErrorResume { e -> telegramApi.sendMessage(chatId, "Document handling failed: ${e.message}")!! }
             .then()
     }
 
     private fun handlePhoto(chatId: Long, message: TelegramUpdate.Message): Mono<Void> {
         val photoList = message.photo ?: return Mono.empty()
         val largest = photoList.lastOrNull() ?: return Mono.empty()
-        val fileId = largest.fileId
-        val fileName = "photo_${largest.fileUniqueId}.jpg"
+        val fileId = largest.fileId ?: return Mono.empty()
+        val fileName = "photo_${largest.fileUniqueId ?: message.messageId}.jpg"
         log.info("Photo received: fileId={}", fileId)
 
         return telegramApi.downloadFileToLocal(fileId, fileName)!!
@@ -253,15 +264,15 @@ class HandleUpdateService(
                 val bytes = try {
                     Files.readAllBytes(localPath)
                 } catch (e: Exception) {
-                    log.warn("photo read error", e)
-                    return@flatMap telegramApi.sendMessage(chatId, "사진 읽기 오류: ${e.message}")!!.then()
+                    log.warn("Photo read error", e)
+                    return@flatMap telegramApi.sendMessage(chatId, "Failed to read photo: ${e.message}")!!.then()
                 }
 
                 val telegramMessageId = message.messageId ?: 0L
                 val fromUserName = message.senderDisplayName()
                     ?: message.from?.firstName?.takeIf { it.isNotBlank() }
                     ?: message.from?.username?.takeIf { it.isNotBlank() }
-                    ?: "사용자"
+                    ?: "User"
 
                 aiServerUpload.upload(
                     bytes = bytes,
@@ -286,14 +297,14 @@ class HandleUpdateService(
                     val width = largest.width ?: 0
                     val height = largest.height ?: 0
                     val reply = if (saved) {
-                        "이미지 ${width}x${height} 사진을 받았습니다."
+                        "Photo received: ${width}x${height}"
                     } else {
-                        "사진 저장 중 오류가 발생했습니다."
+                        "An error occurred while saving the photo."
                     }
                     telegramApi.sendMessage(chatId, reply)!!
                 }
             }
-            .onErrorResume { e -> telegramApi.sendMessage(chatId, "사진 저장 중 오류: ${e.message}")!! }
+            .onErrorResume { e -> telegramApi.sendMessage(chatId, "Photo handling failed: ${e.message}")!! }
             .then()
     }
 
@@ -302,8 +313,8 @@ class HandleUpdateService(
         log.info("Voice received: fileId={}", fileId)
 
         return telegramApi.downloadFileToLocal(fileId, "voice_${message.messageId}.ogg")!!
-            .flatMap { localPath -> telegramApi.sendMessage(chatId, "음성 메시지를 받았습니다. 저장 위치: $localPath")!! }
-            .onErrorResume { e -> telegramApi.sendMessage(chatId, "음성 저장 중 오류: ${e.message}")!! }
+            .flatMap { localPath -> telegramApi.sendMessage(chatId, "Voice message received. Saved at: $localPath")!! }
+            .onErrorResume { e -> telegramApi.sendMessage(chatId, "Voice handling failed: ${e.message}")!! }
             .then()
     }
 
@@ -313,14 +324,16 @@ class HandleUpdateService(
         log.info("Video received: fileId={}", fileId)
 
         return telegramApi.downloadFileToLocal(fileId, fileName)!!
-            .flatMap { localPath -> telegramApi.sendMessage(chatId, "동영상을 받았습니다. 저장 위치: $localPath")!! }
-            .onErrorResume { e -> telegramApi.sendMessage(chatId, "동영상 저장 중 오류: ${e.message}")!! }
+            .flatMap { localPath -> telegramApi.sendMessage(chatId, "Video received. Saved at: $localPath")!! }
+            .onErrorResume { e -> telegramApi.sendMessage(chatId, "Video handling failed: ${e.message}")!! }
             .then()
     }
 
     companion object {
         private const val EXIT_KEYWORD = "bye"
         private val MODE_REPLY_TIMEOUT: Duration = Duration.ofSeconds(3)
-        private const val FALLBACK_MESSAGE = "텍스트나 파일(문서/사진/음성/동영상)을 보내주세요."
+        private val PRIVATE_CHAT_REPLY_TIMEOUT: Duration = Duration.ofSeconds(3)
+        private const val DEFAULT_REPLY_MESSAGE = "I received the message but could not build a reply. Please try again."
+        private const val FALLBACK_MESSAGE = "Please send text or a file (document/photo/voice/video)."
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PrivateChatReplyFallbackFactory.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PrivateChatReplyFallbackFactory.kt
@@ -7,20 +7,62 @@ class PrivateChatReplyFallbackFactory {
 
     fun build(text: String): String {
         val normalized = text.trim()
-        return when {
-            normalized.isBlank() ->
-                "Tell me one more sentence about what is on your mind. I will keep the conversation going."
-
-            normalized.endsWith("?") ->
-                "That is a good question. Let us unpack it one step at a time."
-
-            normalized.contains("tired", ignoreCase = true) ||
-                normalized.contains("lonely", ignoreCase = true) ||
-                normalized.contains("hard", ignoreCase = true) ->
-                "That sounds heavy. You do not have to swallow it all at once. Tell me the next part too."
-
-            else ->
-                "I am listening. Keep going and I will reply right away."
+        return if (prefersEnglish(normalized)) {
+            buildEnglishReply(normalized)
+        } else {
+            buildKoreanReply(normalized)
         }
     }
+
+    private fun buildKoreanReply(text: String): String =
+        when {
+            text.isBlank() ->
+                "마음에 걸리는 내용 한 문장만 더 말해 주세요. 바로 이어서 도와드릴게요."
+
+            text.contains("영어", ignoreCase = true) ->
+                "알겠어요. 이제 영어로 자연스럽게 이어서 대화할게요. 하고 싶은 말을 계속 보내 주세요."
+
+            text.endsWith("?") ||
+                text.contains("왜") ||
+                text.contains("어떻게") ||
+                text.contains("뭐") ->
+                "좋은 질문이에요. 핵심부터 차근차근 같이 풀어볼게요."
+
+            text.contains("힘들", ignoreCase = true) ||
+                text.contains("외롭", ignoreCase = true) ||
+                text.contains("슬프", ignoreCase = true) ||
+                text.contains("지쳤", ignoreCase = true) ||
+                text.contains("불안", ignoreCase = true) ->
+                "많이 버거우셨겠어요. 지금 제일 크게 걸리는 부분부터 편하게 말해 주세요."
+
+            else ->
+                "계속 듣고 있어요. 더 이어서 말해 주시면 그 내용에 맞춰 바로 답할게요."
+        }
+
+    private fun buildEnglishReply(text: String): String =
+        when {
+            text.isBlank() ->
+                "Tell me one more sentence about what is on your mind, and I will keep helping."
+
+            text.endsWith("?") ->
+                "That is a good question. Let us unpack it step by step."
+
+            text.contains("tired", ignoreCase = true) ||
+                text.contains("lonely", ignoreCase = true) ||
+                text.contains("hard", ignoreCase = true) ||
+                text.contains("sad", ignoreCase = true) ->
+                "That sounds heavy. Tell me the hardest part first, and I will stay with you."
+
+            else ->
+                "I am listening. Keep going and I will respond to what you say."
+        }
+
+    private fun prefersEnglish(text: String): Boolean {
+        if (text.contains("영어")) return true
+        if (containsHangul(text)) return false
+        return text.any { it in 'A'..'Z' || it in 'a'..'z' }
+    }
+
+    private fun containsHangul(text: String): Boolean =
+        text.any { ch -> ch in '\uAC00'..'\uD7A3' || ch in '\u3131'..'\u318E' }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PrivateChatReplyFallbackFactory.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PrivateChatReplyFallbackFactory.kt
@@ -1,0 +1,26 @@
+package com.sleekydz86.tellme.showme.application.service
+
+import org.springframework.stereotype.Component
+
+@Component
+class PrivateChatReplyFallbackFactory {
+
+    fun build(text: String): String {
+        val normalized = text.trim()
+        return when {
+            normalized.isBlank() ->
+                "Tell me one more sentence about what is on your mind. I will keep the conversation going."
+
+            normalized.endsWith("?") ->
+                "That is a good question. Let us unpack it one step at a time."
+
+            normalized.contains("tired", ignoreCase = true) ||
+                normalized.contains("lonely", ignoreCase = true) ||
+                normalized.contains("hard", ignoreCase = true) ->
+                "That sounds heavy. You do not have to swallow it all at once. Tell me the next part too."
+
+            else ->
+                "I am listening. Keep going and I will reply right away."
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/TimeAlarmInputParser.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/TimeAlarmInputParser.kt
@@ -1,0 +1,131 @@
+package com.sleekydz86.tellme.showme.application.service
+
+import org.springframework.stereotype.Component
+import java.time.LocalTime
+
+@Component
+class TimeAlarmInputParser {
+
+    fun parseSchedule(input: String): ParsedAlarmInput? =
+        parseDailyTime(input) ?: parseInterval(input)
+
+    fun parseInterval(input: String): ParsedAlarmInput? {
+        val normalized = normalize(input)
+        if (normalized.isBlank()) {
+            return null
+        }
+
+        normalized.toIntOrNull()?.let { minutes ->
+            return when {
+                minutes in 1..60 -> ParsedAlarmInput.Interval(minutes)
+                minutes > 60 -> ParsedAlarmInput.AmbiguousLongMinutes(minutes)
+                else -> null
+            }
+        }
+
+        if (CLOCK_TEXT_REGEX.containsMatchIn(normalized) || CLOCK_COLON_REGEX.containsMatchIn(normalized)) {
+            return null
+        }
+
+        val hasHourUnit = HOUR_REGEX.containsMatchIn(normalized)
+        val minuteMatches = MINUTE_REGEX.findAll(normalized).toList()
+        val hasMinuteUnit = minuteMatches.isNotEmpty()
+        if (!hasHourUnit && !hasMinuteUnit) {
+            return null
+        }
+
+        val hours = HOUR_REGEX.findAll(normalized).sumOf { it.groupValues[1].toInt() }
+        val minutesOnly = minuteMatches.sumOf { it.groupValues[1].toInt() }
+        val totalMinutes = (hours * 60) + minutesOnly
+
+        if (totalMinutes <= 0) {
+            return null
+        }
+        if (hours == 0 && minutesOnly > 60) {
+            return ParsedAlarmInput.AmbiguousLongMinutes(minutesOnly)
+        }
+        if (totalMinutes > MAX_INTERVAL_MINUTES) {
+            return ParsedAlarmInput.TooLargeInterval(totalMinutes)
+        }
+
+        return ParsedAlarmInput.Interval(totalMinutes)
+    }
+
+    fun parseDailyTime(input: String): ParsedAlarmInput.DailyTime? {
+        val normalized = normalize(input)
+        if (normalized.isBlank()) {
+            return null
+        }
+
+        if (normalized.contains("자정")) {
+            return ParsedAlarmInput.DailyTime(LocalTime.MIDNIGHT)
+        }
+        if (normalized.contains("정오")) {
+            return ParsedAlarmInput.DailyTime(LocalTime.NOON)
+        }
+
+        CLOCK_COLON_REGEX.find(normalized)?.let { match ->
+            val hour = match.groupValues[1].toInt()
+            val minute = match.groupValues[2].toInt()
+            if (hour in 0..23 && minute in 0..59) {
+                return ParsedAlarmInput.DailyTime(LocalTime.of(hour, minute))
+            }
+        }
+
+        CLOCK_TEXT_REGEX.find(normalized)?.let { match ->
+            val meridiem = match.groupValues[1]
+            val rawHour = match.groupValues[2].toInt()
+            val minute = match.groupValues.getOrNull(3)?.takeIf { it.isNotBlank() }?.toInt() ?: 0
+            if (minute !in 0..59) {
+                return null
+            }
+
+            val convertedHour = convertClockHour(rawHour, meridiem) ?: return null
+            return ParsedAlarmInput.DailyTime(LocalTime.of(convertedHour, minute))
+        }
+
+        return null
+    }
+
+    private fun convertClockHour(rawHour: Int, meridiem: String): Int? {
+        val token = meridiem.lowercase()
+        return when (token) {
+            "" -> rawHour.takeIf { it in 0..23 }
+            "오전", "am", "아침", "새벽" -> when (rawHour) {
+                in 1..11 -> rawHour
+                12 -> 0
+                else -> null
+            }
+
+            "오후", "pm", "저녁", "밤" -> when (rawHour) {
+                in 1..11 -> rawHour + 12
+                12 -> 12
+                else -> null
+            }
+
+            else -> null
+        }
+    }
+
+    private fun normalize(input: String): String =
+        input.trim()
+            .replace("한시간", "1시간")
+            .replace("한 시간", "1시간")
+            .replace(Regex("\\s+"), " ")
+
+    sealed interface ParsedAlarmInput {
+        data class Interval(val minutes: Int) : ParsedAlarmInput
+        data class DailyTime(val time: LocalTime) : ParsedAlarmInput
+        data class AmbiguousLongMinutes(val minutes: Int) : ParsedAlarmInput
+        data class TooLargeInterval(val minutes: Int) : ParsedAlarmInput
+    }
+
+    companion object {
+        private const val MAX_INTERVAL_MINUTES = 1440
+        private val HOUR_REGEX = Regex("""(\d{1,2})\s*시간""")
+        private val MINUTE_REGEX = Regex("""(\d{1,4})\s*분(?:\s*(?:뒤|후|간격|마다))?""")
+        private val CLOCK_COLON_REGEX = Regex("""(?<!\d)(\d{1,2})\s*:\s*(\d{1,2})(?!\d)""")
+        private val CLOCK_TEXT_REGEX =
+            Regex("""(?:(오전|오후|am|pm|아침|새벽|저녁|밤)\s*)?(\d{1,2})\s*시(?!간)(?:\s*(\d{1,2})\s*분)?""")
+    }
+}

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/TimeAlarmService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/TimeAlarmService.kt
@@ -1,6 +1,7 @@
 package com.sleekydz86.tellme.showme.application.service
 
 import com.sleekydz86.tellme.global.config.TelegramBotProperties
+import com.sleekydz86.tellme.showme.application.service.TimeAlarmInputParser.ParsedAlarmInput
 import com.sleekydz86.tellme.showme.domain.AlarmType
 import com.sleekydz86.tellme.showme.infrastructure.persistence.TelegramAlarmEntity
 import com.sleekydz86.tellme.showme.infrastructure.persistence.TelegramAlarmRepository
@@ -16,7 +17,8 @@ import java.util.Locale
 class TimeAlarmService(
     private val setupStateStore: TimeAlarmSetupStateStore,
     private val alarmRepository: TelegramAlarmRepository,
-    private val properties: TelegramBotProperties
+    private val properties: TelegramBotProperties,
+    private val inputParser: TimeAlarmInputParser
 ) {
     private val formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일 EEEE a h시 mm분 ss초", Locale.KOREAN)
     private val shortFormatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일 a h시 mm분", Locale.KOREAN)
@@ -30,6 +32,21 @@ class TimeAlarmService(
     fun hasPendingSetup(chatId: Long): Boolean = setupStateStore.get(chatId) != null
 
     fun cancelSetup(chatId: Long): Boolean = setupStateStore.clear(chatId) != null
+
+    fun stopActiveAlarms(chatId: Long): Int {
+        val alarms = alarmRepository.findByChatIdAndActiveTrue(chatId)
+        if (alarms.isEmpty()) {
+            return 0
+        }
+
+        val now = nowLocalDateTime()
+        alarms.forEach { alarm ->
+            alarm.active = false
+            alarm.updatedAt = now
+        }
+        alarmRepository.saveAll(alarms)
+        return alarms.size
+    }
 
     fun continueSetup(chatId: Long, input: String): String {
         val state = setupStateStore.get(chatId) ?: return "진행 중인 알람 설정이 없습니다."
@@ -45,6 +62,7 @@ class TimeAlarmService(
             TimeAlarmSetupStep.TYPE -> handleType(chatId, normalized)
             TimeAlarmSetupStep.INTERVAL_MINUTES -> handleIntervalMinutes(chatId, normalized)
             TimeAlarmSetupStep.DAILY_TIME -> handleDailyTime(chatId, normalized)
+            TimeAlarmSetupStep.MESSAGE -> handleMessage(chatId, state, normalized)
         }
     }
 
@@ -62,36 +80,37 @@ class TimeAlarmService(
     }
 
     fun buildAlarmNotificationMessage(alarm: TelegramAlarmEntity): String {
-        val typeLabel = when (alarm.alarmType) {
-            AlarmType.INTERVAL -> "반복 간격"
-            AlarmType.DAILY_TIME -> "특정 시간"
-        }
+        val body = alarm.messageText?.trim().takeIf { !it.isNullOrBlank() }
+            ?: "다시 한 번 현재 시각입니다. 알람 메시지입니다."
         return buildString {
-            appendLine("다시 한 번 현재 시각입니다. 알람 메시지입니다.")
-            appendLine("알람 종류: $typeLabel")
+            appendLine(body)
+            appendLine()
             append("현재 시각: ${format(nowZonedDateTime())}")
         }
     }
 
     fun buildCurrentTimeMessage(): String = "현재 시각은 ${format(nowZonedDateTime())}입니다."
 
-    private fun handleConfirm(chatId: Long, input: String): String =
-        when {
-            isPositive(input) -> {
-                setupStateStore.put(chatId, TimeAlarmSetupState(TimeAlarmSetupStep.TYPE))
-                "좋아요. 시간 간격으로 받을까요, 특정 시간에 받을까요? 간격 또는 시간 으로 답해 주세요."
-            }
-
-            isNegative(input) -> {
-                setupStateStore.clear(chatId)
-                "알람 설정 없이 현재 시각만 안내했어요."
-            }
-
-            else -> "알람을 받을지 먼저 알려주세요. 예 또는 아니오 로 답해 주세요."
+    private fun handleConfirm(chatId: Long, input: String): String {
+        if (isNegative(input)) {
+            setupStateStore.clear(chatId)
+            return "알람 설정 없이 현재 시각만 안내했어요."
         }
 
-    private fun handleType(chatId: Long, input: String): String =
-        when {
+        createAlarmIfPossible(chatId, input)?.let { return it }
+
+        return if (isPositive(input)) {
+            setupStateStore.put(chatId, TimeAlarmSetupState(TimeAlarmSetupStep.TYPE))
+            "좋아요. 시간 간격으로 받을까요, 특정 시간에 받을까요? 간격 또는 시간 으로 답해 주세요. 예: 5분 뒤, 1시간 10분, 오후 9시 30분"
+        } else {
+            "알람을 받을지 먼저 알려주세요. 예 또는 아니오 로 답해 주세요. 바로 5분 뒤, 오후 9시 30분처럼 말해도 돼요."
+        }
+    }
+
+    private fun handleType(chatId: Long, input: String): String {
+        createAlarmIfPossible(chatId, input)?.let { return it }
+
+        return when {
             isIntervalType(input) -> {
                 setupStateStore.put(
                     chatId,
@@ -100,7 +119,7 @@ class TimeAlarmService(
                         alarmType = AlarmType.INTERVAL
                     )
                 )
-                "몇 분 간격으로 받을까요? 10 처럼 분 단위 숫자를 입력해 주세요."
+                "몇 분 간격으로 받을까요? 숫자만 보내면 1분에서 60분까지 이해할 수 있어요. 1시간 이상이면 1시간 10분처럼 적어 주세요."
             }
 
             isSpecificTimeType(input) -> {
@@ -111,18 +130,90 @@ class TimeAlarmService(
                         alarmType = AlarmType.DAILY_TIME
                     )
                 )
-                "매일 언제 받을까요? HH:mm 형식으로 입력해 주세요. 예: 09:30"
+                "몇 시 몇 분에 받을까요? 예: 21:30, 오후 9시 30분, 오전 7시"
             }
 
-            else -> "간격 또는 시간 중 하나로 답해 주세요."
+            else -> "간격 또는 시간 중 하나로 답해 주세요. 바로 5분 뒤, 1시간 1분, 오후 9시 30분처럼 말해도 됩니다."
+        }
+    }
+
+    private fun handleIntervalMinutes(chatId: Long, input: String): String =
+        when (val parsed = inputParser.parseInterval(input)) {
+            is ParsedAlarmInput.Interval -> prepareAlarmMessage(chatId, AlarmType.INTERVAL, parsed.minutes, null)
+            is ParsedAlarmInput.AmbiguousLongMinutes -> buildLongMinuteClarification(parsed.minutes)
+            is ParsedAlarmInput.TooLargeInterval ->
+                "간격은 최대 24시간까지만 설정할 수 있어요. 더 짧게 다시 입력해 주세요."
+            is ParsedAlarmInput.DailyTime ->
+                prepareAlarmMessage(chatId, AlarmType.DAILY_TIME, null, parsed.time)
+            null -> "간격을 이해하지 못했어요. 5, 5분, 1시간, 1시간 10분처럼 입력해 주세요."
         }
 
-    private fun handleIntervalMinutes(chatId: Long, input: String): String {
-        val minutes = input.toIntOrNull()
-        if (minutes == null || minutes !in 1..1440) {
-            return "간격은 1분에서 1440분 사이 숫자로 입력해 주세요."
+    private fun handleDailyTime(chatId: Long, input: String): String =
+        when (val parsed = inputParser.parseSchedule(input)) {
+            is ParsedAlarmInput.DailyTime -> prepareAlarmMessage(chatId, AlarmType.DAILY_TIME, null, parsed.time)
+            is ParsedAlarmInput.Interval -> prepareAlarmMessage(chatId, AlarmType.INTERVAL, parsed.minutes, null)
+            is ParsedAlarmInput.AmbiguousLongMinutes -> buildLongMinuteClarification(parsed.minutes)
+            is ParsedAlarmInput.TooLargeInterval ->
+                "간격은 최대 24시간까지만 설정할 수 있어요. 더 짧게 다시 입력해 주세요."
+            null -> "시간 형식을 이해하지 못했어요. 21:30, 오후 9시 30분, 오전 7시처럼 입력해 주세요."
         }
 
+    private fun handleMessage(chatId: Long, state: TimeAlarmSetupState, input: String): String {
+        val messageText = normalizeAlarmMessage(input)
+        return when (state.alarmType) {
+            AlarmType.INTERVAL -> {
+                val minutes = state.intervalMinutes
+                    ?: return resetBrokenSetup(chatId, "알람 간격 정보가 사라졌어요. /time 으로 다시 시작해 주세요.")
+                saveIntervalAlarm(chatId, minutes, messageText)
+            }
+
+            AlarmType.DAILY_TIME -> {
+                val time = state.timeOfDay
+                    ?: return resetBrokenSetup(chatId, "알람 시간 정보가 사라졌어요. /time 으로 다시 시작해 주세요.")
+                saveDailyAlarm(chatId, time, messageText)
+            }
+
+            null -> resetBrokenSetup(chatId, "알람 정보가 충분하지 않아요. /time 으로 다시 시작해 주세요.")
+        }
+    }
+
+    private fun createAlarmIfPossible(chatId: Long, input: String): String? =
+        when (val parsed = inputParser.parseSchedule(input)) {
+            is ParsedAlarmInput.Interval -> prepareAlarmMessage(chatId, AlarmType.INTERVAL, parsed.minutes, null)
+            is ParsedAlarmInput.DailyTime -> prepareAlarmMessage(chatId, AlarmType.DAILY_TIME, null, parsed.time)
+            is ParsedAlarmInput.AmbiguousLongMinutes -> buildLongMinuteClarification(parsed.minutes)
+            is ParsedAlarmInput.TooLargeInterval ->
+                "간격은 최대 24시간까지만 설정할 수 있어요. 더 짧게 다시 입력해 주세요."
+            null -> null
+        }
+
+    private fun prepareAlarmMessage(
+        chatId: Long,
+        alarmType: AlarmType,
+        intervalMinutes: Int?,
+        timeOfDay: LocalTime?
+    ): String {
+        setupStateStore.put(
+            chatId,
+            TimeAlarmSetupState(
+                step = TimeAlarmSetupStep.MESSAGE,
+                alarmType = alarmType,
+                intervalMinutes = intervalMinutes,
+                timeOfDay = timeOfDay
+            )
+        )
+
+        val scheduleSummary = when (alarmType) {
+            AlarmType.INTERVAL -> "${formatDuration(intervalMinutes ?: 1)} 간격"
+            AlarmType.DAILY_TIME -> "매일 ${timeOfDay?.format(timeFormatter) ?: "09:00"}"
+        }
+
+        return "좋아요. 알람 문구를 입력해 주세요.\n" +
+            "기본 문구를 쓰려면 기본 또는 skip 이라고 보내 주세요.\n" +
+            "설정한 일정: $scheduleSummary"
+    }
+
+    private fun saveIntervalAlarm(chatId: Long, minutes: Int, messageText: String?): String {
         val now = nowLocalDateTime()
         val nextTriggerAt = now.plusMinutes(minutes.toLong())
         val saved = alarmRepository.save(
@@ -130,19 +221,20 @@ class TimeAlarmService(
                 chatId = chatId,
                 alarmType = AlarmType.INTERVAL,
                 intervalMinutes = minutes,
+                messageText = messageText,
                 nextTriggerAt = nextTriggerAt,
                 createdAt = now,
                 updatedAt = now
             )
         )
         setupStateStore.clear(chatId)
-        return "알람을 저장했어요. ${minutes}분 간격으로 보내드릴게요. 첫 알람 예정 시각: ${formatShort(saved.nextTriggerAt)}"
+        return "알람을 저장했어요. ${formatDuration(minutes)} 간격으로 보내드릴게요.\n" +
+            "알람 문구: ${describeAlarmMessage(messageText)}\n" +
+            "첫 알람 예정 시각: ${formatShort(saved.nextTriggerAt)}\n" +
+            "중지하려면 /alarmstop 또는 /end 를 입력해 주세요."
     }
 
-    private fun handleDailyTime(chatId: Long, input: String): String {
-        val time = parseTime(input)
-            ?: return "시간 형식이 올바르지 않습니다. HH:mm 형식으로 입력해 주세요. 예: 21:30"
-
+    private fun saveDailyAlarm(chatId: Long, time: LocalTime, messageText: String?): String {
         val now = nowLocalDateTime()
         val nextTriggerAt = computeNextDailyTrigger(now, time)
         val saved = alarmRepository.save(
@@ -150,21 +242,68 @@ class TimeAlarmService(
                 chatId = chatId,
                 alarmType = AlarmType.DAILY_TIME,
                 timeOfDay = time,
+                messageText = messageText,
                 nextTriggerAt = nextTriggerAt,
                 createdAt = now,
                 updatedAt = now
             )
         )
         setupStateStore.clear(chatId)
-        return "알람을 저장했어요. 매일 ${time.format(timeFormatter)}에 보내드릴게요. 첫 알람 예정 시각: ${formatShort(saved.nextTriggerAt)}"
+        return "알람을 저장했어요. 매일 ${time.format(timeFormatter)}에 보내드릴게요.\n" +
+            "알람 문구: ${describeAlarmMessage(messageText)}\n" +
+            "첫 알람 예정 시각: ${formatShort(saved.nextTriggerAt)}\n" +
+            "중지하려면 /alarmstop 또는 /end 를 입력해 주세요."
     }
-
-    private fun parseTime(value: String): LocalTime? =
-        runCatching { LocalTime.parse(value.trim(), timeFormatter) }.getOrNull()
 
     private fun computeNextDailyTrigger(reference: LocalDateTime, timeOfDay: LocalTime): LocalDateTime {
         val todayCandidate = reference.toLocalDate().atTime(timeOfDay)
         return if (todayCandidate.isAfter(reference)) todayCandidate else todayCandidate.plusDays(1)
+    }
+
+    private fun buildLongMinuteClarification(minutes: Int): String {
+        val hours = minutes / 60
+        val remainMinutes = minutes % 60
+        val suggestion = buildString {
+            if (hours > 0) {
+                append("${hours}시간")
+            }
+            if (remainMinutes > 0) {
+                if (isNotEmpty()) append(" ")
+                append("${remainMinutes}분")
+            }
+        }.ifBlank { "1시간" }
+
+        return "분으로만 60분을 넘게 입력하면 해석이 헷갈릴 수 있어요. ${suggestion}처럼 다시 정확히 말해 주세요."
+    }
+
+    private fun formatDuration(minutes: Int): String {
+        val hours = minutes / 60
+        val remainMinutes = minutes % 60
+        return buildString {
+            if (hours > 0) {
+                append("${hours}시간")
+            }
+            if (remainMinutes > 0) {
+                if (isNotEmpty()) append(" ")
+                append("${remainMinutes}분")
+            }
+            if (isEmpty()) {
+                append("${minutes}분")
+            }
+        }
+    }
+
+    private fun normalizeAlarmMessage(input: String): String? =
+        input.trim()
+            .takeIf { it.isNotBlank() }
+            ?.takeUnless { isDefaultMessageInput(it) }
+
+    private fun describeAlarmMessage(messageText: String?): String =
+        messageText?.takeIf { it.isNotBlank() } ?: "기본 문구"
+
+    private fun resetBrokenSetup(chatId: Long, message: String): String {
+        setupStateStore.clear(chatId)
+        return message
     }
 
     private fun isPositive(input: String): Boolean =
@@ -181,6 +320,9 @@ class TimeAlarmService(
 
     private fun isCancelInput(input: String): Boolean =
         input.lowercase() in setOf("취소", "cancel", "그만", "bye")
+
+    private fun isDefaultMessageInput(input: String): Boolean =
+        input.lowercase() in setOf("기본", "skip", "건너뛰기", "없음", "default")
 
     private fun nowZonedDateTime(): ZonedDateTime = ZonedDateTime.now(resolveZoneId())
 

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/TimeAlarmSetupStateStore.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/TimeAlarmSetupStateStore.kt
@@ -4,6 +4,8 @@ import com.sleekydz86.tellme.showme.domain.AlarmType
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Component
 import java.time.Duration
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
 @Component
 class TimeAlarmSetupStateStore(
@@ -11,19 +13,34 @@ class TimeAlarmSetupStateStore(
 ) {
     fun get(chatId: Long): TimeAlarmSetupState? {
         val raw = redisTemplate.opsForValue().get(key(chatId)) ?: return null
-        val tokens = raw.split(DELIMITER, limit = 2)
-        val step = runCatching { TimeAlarmSetupStep.valueOf(tokens[0]) }.getOrNull() ?: return null
+        val tokens = raw.split(DELIMITER)
+        val step = tokens.getOrNull(0)
+            ?.let { runCatching { TimeAlarmSetupStep.valueOf(it) }.getOrNull() }
+            ?: return null
         val alarmType = tokens.getOrNull(1)
             ?.takeIf { it.isNotBlank() && it != NULL_TOKEN }
             ?.let { runCatching { AlarmType.valueOf(it) }.getOrNull() }
+        val intervalMinutes = tokens.getOrNull(2)
+            ?.takeIf { it.isNotBlank() && it != NULL_TOKEN }
+            ?.toIntOrNull()
+        val timeOfDay = tokens.getOrNull(3)
+            ?.takeIf { it.isNotBlank() && it != NULL_TOKEN }
+            ?.let { runCatching { LocalTime.parse(it, TIME_FORMATTER) }.getOrNull() }
 
-        return TimeAlarmSetupState(step = step, alarmType = alarmType)
+        return TimeAlarmSetupState(
+            step = step,
+            alarmType = alarmType,
+            intervalMinutes = intervalMinutes,
+            timeOfDay = timeOfDay
+        )
     }
 
     fun put(chatId: Long, state: TimeAlarmSetupState) {
         val raw = listOf(
             state.step.name,
-            state.alarmType?.name ?: NULL_TOKEN
+            state.alarmType?.name ?: NULL_TOKEN,
+            state.intervalMinutes?.toString() ?: NULL_TOKEN,
+            state.timeOfDay?.format(TIME_FORMATTER) ?: NULL_TOKEN
         ).joinToString(DELIMITER)
         redisTemplate.opsForValue().set(key(chatId), raw, SETUP_TTL)
     }
@@ -40,17 +57,21 @@ class TimeAlarmSetupStateStore(
         private const val DELIMITER = "|"
         private const val NULL_TOKEN = "-"
         private val SETUP_TTL: Duration = Duration.ofMinutes(30)
+        private val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
     }
 }
 
 data class TimeAlarmSetupState(
     val step: TimeAlarmSetupStep,
-    val alarmType: AlarmType? = null
+    val alarmType: AlarmType? = null,
+    val intervalMinutes: Int? = null,
+    val timeOfDay: LocalTime? = null
 )
 
 enum class TimeAlarmSetupStep {
     CONFIRM,
     TYPE,
     INTERVAL_MINUTES,
-    DAILY_TIME
+    DAILY_TIME,
+    MESSAGE
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/AlarmStopCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/AlarmStopCommandHandler.kt
@@ -1,0 +1,27 @@
+package com.sleekydz86.tellme.showme.application.service.handler
+
+import com.sleekydz86.tellme.showme.application.service.TimeAlarmService
+import com.sleekydz86.tellme.showme.domain.MessageContext
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class AlarmStopCommandHandler(
+    private val timeAlarmService: TimeAlarmService
+) : CommandHandler {
+
+    override fun handle(ctx: MessageContext?): Mono<String> {
+        if (ctx == null || !ctx.supportsAlarmSetup()) {
+            return Mono.just("프론트 채팅에서는 텔레그램 알람을 중지할 수 없어요. 텔레그램에서 /alarmstop 을 입력해 주세요.")
+        }
+
+        val chatId = ctx.chatId ?: return Mono.just("채팅 정보를 찾지 못했어요.")
+        val stopped = timeAlarmService.stopActiveAlarms(chatId)
+
+        return if (stopped > 0) {
+            Mono.just("활성 알람 ${stopped}개를 중지했어요.")
+        } else {
+            Mono.just("현재 중지할 활성 알람이 없어요.")
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/EndCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/EndCommandHandler.kt
@@ -16,25 +16,26 @@ class EndCommandHandler(
         val chatId = ctx?.chatId ?: return Mono.just(NO_ACTIVE_STATE_MESSAGE)
         val mode = conversationModeStore.clear(chatId)
         val alarmSetupCancelled = timeAlarmService.cancelSetup(chatId)
+        val stoppedAlarmCount = if (ctx.supportsAlarmSetup()) timeAlarmService.stopActiveAlarms(chatId) else 0
 
-        val reply = when {
-            mode != null && alarmSetupCancelled ->
-                "${mode.label}와 알람 설정을 종료했어요. 이제 원래 대화로 돌아왔습니다."
-
-            mode != null ->
-                "${mode.label}를 종료했어요. 이제 원래 대화로 돌아왔습니다."
-
-            alarmSetupCancelled ->
-                "알람 설정을 종료했어요."
-
-            else ->
-                NO_ACTIVE_STATE_MESSAGE
-        }
+        val reply = buildString {
+            if (mode != null) {
+                append("${mode.label}를 종료했어요.")
+            }
+            if (alarmSetupCancelled) {
+                if (isNotEmpty()) append(" ")
+                append("알람 설정을 취소했어요.")
+            }
+            if (stoppedAlarmCount > 0) {
+                if (isNotEmpty()) append(" ")
+                append("활성 알람 ${stoppedAlarmCount}개도 함께 중지했어요.")
+            }
+        }.ifBlank { NO_ACTIVE_STATE_MESSAGE }
 
         return Mono.just(reply)
     }
 
     companion object {
-        private const val NO_ACTIVE_STATE_MESSAGE = "현재 종료할 대화나 알람 설정이 없습니다."
+        private const val NO_ACTIVE_STATE_MESSAGE = "현재 종료할 대화나 알람 설정이 없어요."
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/HelpCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/HelpCommandHandler.kt
@@ -15,11 +15,12 @@ class HelpCommandHandler : CommandHandler {
             "지원 기능:\n" +
                 "- /start : 시작 메시지\n" +
                 "- /time : 현재 시간 안내 후 알람 설정\n" +
+                "- /alarmstop : 실행 중인 알람 중지\n" +
                 "- /lotto : 로또 번호\n" +
                 "- /eng : AiServer 영어 대화 모드 시작\n" +
                 "- /god : AiServer 명언 대화 모드 시작\n" +
-                "- /search 질문 : /channel 에 업로드한 문서 기반 검색\n" +
-                "- /end : /eng, /god, 알람 설정 흐름 종료\n" +
+                "- /search 질문 : /channel 문서를 기반으로 검색\n" +
+                "- /end : 대화 모드, 알람 설정, 활성 알람 종료\n" +
                 "- bye : /eng 또는 /god 대화 모드 종료\n" +
                 "- 문서/사진/음성/동영상 전송 : 파일 다운로드"
             )

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/HelpCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/HelpCommandHandler.kt
@@ -13,6 +13,7 @@ class HelpCommandHandler : CommandHandler {
     companion object {
         private const val BODY = (
             "지원 기능:\n" +
+                "- 일반 질문 : 명령어 없이 보내도 AI가 응답\n" +
                 "- /start : 시작 메시지\n" +
                 "- /time : 현재 시간 안내 후 알람 설정\n" +
                 "- /alarmstop : 실행 중인 알람 중지\n" +

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/StartCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/StartCommandHandler.kt
@@ -13,6 +13,8 @@ class StartCommandHandler : CommandHandler {
 
     companion object {
         private const val TEMPLATE =
-            "%s님 안녕하세요. 사용 가능한 명령어는 /time, /lotto, /god, /eng, /search, /end 입니다. /time 은 현재 시각 안내 후 알람 설정까지 이어지고, /eng 와 /god 는 대화 모드이며 bye 또는 /end 로 종료할 수 있어요."
+            "%s님 안녕하세요. 사용 가능한 명령어는 /time, /alarmstop, /lotto, /god, /eng, /search, /end 입니다. " +
+                "/time 은 현재 시각 안내 후 알람 설정까지 이어지고, 알람 문구도 직접 정할 수 있어요. " +
+                "/eng 와 /god 는 대화 모드이며 bye 또는 /end 로 종료할 수 있습니다."
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/StartCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/StartCommandHandler.kt
@@ -14,6 +14,7 @@ class StartCommandHandler : CommandHandler {
     companion object {
         private const val TEMPLATE =
             "%s님 안녕하세요. 사용 가능한 명령어는 /time, /alarmstop, /lotto, /god, /eng, /search, /end 입니다. " +
+                "명령어 없이 일반 질문을 보내도 AI가 바로 응답할 수 있어요. " +
                 "/time 은 현재 시각 안내 후 알람 설정까지 이어지고, 알람 문구도 직접 정할 수 있어요. " +
                 "/eng 와 /god 는 대화 모드이며 bye 또는 /end 로 종료할 수 있습니다."
     }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/TimeCommandHandler.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/handler/TimeCommandHandler.kt
@@ -10,7 +10,7 @@ class TimeCommandHandler(
     private val timeAlarmService: TimeAlarmService
 ) : CommandHandler {
     override fun handle(ctx: MessageContext?): Mono<String> {
-        val chatId = ctx?.chatId ?: return Mono.just("채팅 정보를 찾지 못했습니다.")
+        val chatId = ctx?.chatId ?: return Mono.just("채팅 정보를 찾지 못했어요.")
         return Mono.just(timeAlarmService.startSetup(chatId))
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/BotCommand.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/BotCommand.kt
@@ -17,20 +17,19 @@ enum class BotCommand(
     companion object {
         fun from(text: String?, allowBareAliases: Boolean = false): BotCommand? {
             if (text == null || text.isBlank()) return null
-            val commandToken = text.trim()
+            val trimmed = text.trim()
+            val commandToken = trimmed
                 .substringBefore(" ")
                 .substringBefore("@")
-            return entries.find { it.matches(commandToken, allowBareAliases) }
+            entries.find { it.value.equals(commandToken, ignoreCase = true) }?.let { return it }
+            if (!allowBareAliases) {
+                return null
+            }
+            return entries.find { it.matchesBareAlias(trimmed) }
         }
     }
 
-    private fun matches(commandToken: String, allowBareAliases: Boolean): Boolean {
-        if (value.equals(commandToken, ignoreCase = true)) {
-            return true
-        }
-        if (!allowBareAliases) {
-            return false
-        }
-        return aliases.any { alias -> alias.equals(commandToken, ignoreCase = true) }
+    private fun matchesBareAlias(text: String): Boolean {
+        return aliases.any { alias -> alias.equals(text, ignoreCase = true) }
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/BotCommand.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/BotCommand.kt
@@ -1,22 +1,36 @@
 package com.sleekydz86.tellme.showme.domain
 
-enum class BotCommand(val value: String) {
-    START("/start"),
-    TIME("/time"),
-    HELP("/help"),
-    LOTTO("/lotto"),
-    GOD("/god"),
-    ENG("/eng"),
-    END("/end"),
-    SEARCH("/search");
+enum class BotCommand(
+    val value: String,
+    private vararg val aliases: String
+) {
+    START("/start", "start"),
+    TIME("/time", "time"),
+    HELP("/help", "help"),
+    LOTTO("/lotto", "lotto"),
+    GOD("/god", "god"),
+    ENG("/eng", "eng"),
+    ALARM_STOP("/alarmstop", "alarmstop", "alarm-stop", "알람중지", "알람중단"),
+    END("/end", "end"),
+    SEARCH("/search", "search");
 
     companion object {
-        fun from(text: String?): BotCommand? {
+        fun from(text: String?, allowBareAliases: Boolean = false): BotCommand? {
             if (text == null || text.isBlank()) return null
             val commandToken = text.trim()
                 .substringBefore(" ")
                 .substringBefore("@")
-            return entries.find { it.value == commandToken }
+            return entries.find { it.matches(commandToken, allowBareAliases) }
         }
+    }
+
+    private fun matches(commandToken: String, allowBareAliases: Boolean): Boolean {
+        if (value.equals(commandToken, ignoreCase = true)) {
+            return true
+        }
+        if (!allowBareAliases) {
+            return false
+        }
+        return aliases.any { alias -> alias.equals(commandToken, ignoreCase = true) }
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/ConversationMode.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/ConversationMode.kt
@@ -1,8 +1,8 @@
 package com.sleekydz86.tellme.showme.domain
 
 enum class ConversationMode(val aiMode: String, val label: String) {
-    ENG("eng", "영어 대화"),
-    GOD("god", "명언 대화");
+    ENG("eng", "English mode"),
+    GOD("god", "Quote mode");
 
     companion object {
         fun fromAiMode(value: String?): ConversationMode? =

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/InputSource.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/InputSource.kt
@@ -1,0 +1,8 @@
+package com.sleekydz86.tellme.showme.domain
+
+enum class InputSource {
+    TELEGRAM,
+    FRONTEND;
+
+    fun supportsAlarmSetup(): Boolean = this == TELEGRAM
+}

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/MessageContext.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/MessageContext.kt
@@ -6,9 +6,14 @@ data class MessageContext(
     val chatId: Long? = null,
     val text: String? = null,
     val firstName: String? = null,
-    val chatType: String? = null
+    val chatType: String? = null,
+    val inputSource: InputSource = InputSource.TELEGRAM
 ) {
     fun isPrivateChat(): Boolean = chatType.equals("private", ignoreCase = true)
+
+    fun isFrontend(): Boolean = inputSource == InputSource.FRONTEND
+
+    fun supportsAlarmSetup(): Boolean = inputSource.supportsAlarmSetup()
 
     fun commandArgument(): String? {
         val trimmed = text?.trim().orEmpty()
@@ -25,11 +30,13 @@ data class MessageContext(
     companion object {
         fun from(message: TelegramUpdate.Message?): MessageContext? {
             if (message == null) return null
-            val chatId = message.chat?.id
-            val text = message.text?.trim() ?: ""
-            val firstName = message.from?.firstName ?: "사용자"
-            val chatType = message.chat?.type
-            return MessageContext(chatId = chatId, text = text, firstName = firstName, chatType = chatType)
+            return MessageContext(
+                chatId = message.chat?.id,
+                text = message.text?.trim().orEmpty(),
+                firstName = message.from?.firstName ?: "User",
+                chatType = message.chat?.type,
+                inputSource = InputSource.TELEGRAM
+            )
         }
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/adapter/AiServerWebClientAdapter.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/adapter/AiServerWebClientAdapter.kt
@@ -2,6 +2,7 @@ package com.sleekydz86.tellme.showme.infrastructure.adapter
 
 import com.sleekydz86.tellme.showme.application.port.AiServerHistoryPort
 import com.sleekydz86.tellme.showme.application.port.AiServerModeChatPort
+import com.sleekydz86.tellme.showme.application.port.AiServerReplyPort
 import com.sleekydz86.tellme.showme.application.port.AiServerSearchPort
 import com.sleekydz86.tellme.showme.application.port.AiServerTelegramPort
 import com.sleekydz86.tellme.showme.application.port.AiServerUploadPort
@@ -23,7 +24,7 @@ import java.time.Instant
 @Component
 class AiServerWebClientAdapter(
     @Qualifier("aiServerWebClient") private val webClient: WebClient
-) : AiServerUploadPort, AiServerTelegramPort, AiServerHistoryPort, AiServerSearchPort, AiServerModeChatPort {
+) : AiServerUploadPort, AiServerTelegramPort, AiServerHistoryPort, AiServerSearchPort, AiServerModeChatPort, AiServerReplyPort {
     private val log = LoggerFactory.getLogger(AiServerWebClientAdapter::class.java)
 
     override fun upload(
@@ -149,6 +150,27 @@ class AiServerWebClientAdapter(
             .switchIfEmpty(Mono.error(IllegalStateException("AiServer mode reply is blank: mode=${mode.aiMode}")))
             .doOnError { e ->
                 log.warn("Failed to chat with AiServer mode: userId={}, mode={}", userId, mode.aiMode, e)
+            }
+    }
+
+    override fun reply(userId: String, message: String): Mono<String> {
+        val body = mapOf(
+            "currentUserName" to userId,
+            "message" to message,
+            "useKnowledgeBase" to false
+        )
+        return webClient.post()
+            .uri("/chat/reply")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(body)
+            .retrieve()
+            .bodyToMono(String::class.java)
+            .timeout(AI_SERVER_RESPONSE_TIMEOUT)
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .switchIfEmpty(Mono.error(IllegalStateException("AiServer reply is blank")))
+            .doOnError { e ->
+                log.warn("Failed to chat with AiServer general reply: userId={}", userId, e)
             }
     }
 

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/persistence/TelegramAlarmEntity.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/persistence/TelegramAlarmEntity.kt
@@ -32,6 +32,9 @@ class TelegramAlarmEntity(
     @Column
     var timeOfDay: LocalTime? = null,
 
+    @Column(length = 500)
+    var messageText: String? = null,
+
     @Column(nullable = false)
     var nextTriggerAt: LocalDateTime = LocalDateTime.now(),
 

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/persistence/TelegramAlarmRepository.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/persistence/TelegramAlarmRepository.kt
@@ -5,4 +5,5 @@ import java.time.LocalDateTime
 
 interface TelegramAlarmRepository : JpaRepository<TelegramAlarmEntity, Long> {
     fun findByActiveTrueAndNextTriggerAtLessThanEqualOrderByNextTriggerAtAsc(now: LocalDateTime): List<TelegramAlarmEntity>
+    fun findByChatIdAndActiveTrue(chatId: Long): List<TelegramAlarmEntity>
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/web/FrontendChatController.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/web/FrontendChatController.kt
@@ -1,0 +1,50 @@
+package com.sleekydz86.tellme.showme.infrastructure.web
+
+import com.sleekydz86.tellme.showme.application.service.FrontendChatSessionIdCodec
+import com.sleekydz86.tellme.showme.application.service.HandleUpdateService
+import com.sleekydz86.tellme.showme.domain.InputSource
+import com.sleekydz86.tellme.showme.domain.MessageContext
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
+
+@RestController
+class FrontendChatController(
+    private val handleUpdateService: HandleUpdateService,
+    private val sessionIdCodec: FrontendChatSessionIdCodec
+) {
+
+    @PostMapping(value = ["/chat_input.do"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun chatInput(@RequestBody request: FrontendChatRequest): Mono<ResponseEntity<FrontendChatResponse>> {
+        val sessionId = request.sessionId.trim().ifBlank { "frontend-anonymous" }
+        val text = request.message.trim()
+        if (text.isBlank()) {
+            return Mono.just(ResponseEntity.ok(FrontendChatResponse(sessionId, "Please enter a message.")))
+        }
+
+        val ctx = MessageContext(
+            chatId = sessionIdCodec.toChatId(sessionId),
+            text = text,
+            firstName = request.displayName?.trim().takeUnless { it.isNullOrBlank() } ?: "Frontend user",
+            chatType = "private",
+            inputSource = InputSource.FRONTEND
+        )
+
+        return handleUpdateService.replyForContext(ctx)
+            .map { reply -> ResponseEntity.ok(FrontendChatResponse(sessionId, reply)) }
+    }
+}
+
+data class FrontendChatRequest(
+    val sessionId: String = "",
+    val message: String = "",
+    val displayName: String? = null
+)
+
+data class FrontendChatResponse(
+    val sessionId: String,
+    val reply: String
+)

--- a/backend/src/test/kotlin/com/sleekydz86/tellme/showme/application/service/TimeAlarmInputParserTests.kt
+++ b/backend/src/test/kotlin/com/sleekydz86/tellme/showme/application/service/TimeAlarmInputParserTests.kt
@@ -1,0 +1,60 @@
+package com.sleekydz86.tellme.showme.application.service
+
+import com.sleekydz86.tellme.showme.application.service.TimeAlarmInputParser.ParsedAlarmInput
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import java.time.LocalTime
+
+class TimeAlarmInputParserTests {
+
+    private val parser = TimeAlarmInputParser()
+
+    @Test
+    fun `parse plain minute number`() {
+        val result = parser.parseInterval("5")
+
+        assertInstanceOf(ParsedAlarmInput.Interval::class.java, result)
+        assertEquals(5, (result as ParsedAlarmInput.Interval).minutes)
+    }
+
+    @Test
+    fun `parse relative minute expression`() {
+        val result = parser.parseSchedule("5분 뒤 해줘")
+
+        assertInstanceOf(ParsedAlarmInput.Interval::class.java, result)
+        assertEquals(5, (result as ParsedAlarmInput.Interval).minutes)
+    }
+
+    @Test
+    fun `parse hour and minute interval expression`() {
+        val result = parser.parseSchedule("1시간 1분")
+
+        assertInstanceOf(ParsedAlarmInput.Interval::class.java, result)
+        assertEquals(61, (result as ParsedAlarmInput.Interval).minutes)
+    }
+
+    @Test
+    fun `request clarification for long minute only expression`() {
+        val result = parser.parseSchedule("90분")
+
+        assertInstanceOf(ParsedAlarmInput.AmbiguousLongMinutes::class.java, result)
+        assertEquals(90, (result as ParsedAlarmInput.AmbiguousLongMinutes).minutes)
+    }
+
+    @Test
+    fun `parse daily time with meridiem`() {
+        val result = parser.parseSchedule("오후 9시 30분")
+
+        assertInstanceOf(ParsedAlarmInput.DailyTime::class.java, result)
+        assertEquals(LocalTime.of(21, 30), (result as ParsedAlarmInput.DailyTime).time)
+    }
+
+    @Test
+    fun `parse daily time with colon`() {
+        val result = parser.parseSchedule("21:30")
+
+        assertInstanceOf(ParsedAlarmInput.DailyTime::class.java, result)
+        assertEquals(LocalTime.of(21, 30), (result as ParsedAlarmInput.DailyTime).time)
+    }
+}

--- a/frontend/src/application/hooks/useAiChat.ts
+++ b/frontend/src/application/hooks/useAiChat.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { createChatMessage, type ChatMessage } from '@/domain/chat';
 import { aiServerApiRepository } from '@/infrastructure/api/AiServerApiRepository';
 
@@ -8,9 +8,13 @@ function generateUserId(): string {
   return `frontend-user-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 }
 
-const INITIAL_MESSAGE = '시작 버튼을 누른 뒤 메시지를 보내면 AiServer와 바로 대화할 수 있어요.';
-const CONNECTION_ERROR_MESSAGE = 'AiServer SSE 연결에 실패했습니다. 6060 포트가 실행 중인지 확인해 주세요.';
-const SEND_ERROR_MESSAGE = 'AiServer로 메시지를 보내지 못했습니다. 서버 상태를 확인해 주세요.';
+const INITIAL_MESSAGE =
+  'You can use normal chat and commands like /god, /eng, and /search here. ' +
+  'Bare aliases such as god, eng, and search are also recognized in the frontend. ' +
+  'The /time command only returns safe guidance here and does not create Telegram alarms.';
+
+const SEND_ERROR_MESSAGE =
+  'The chat request could not be completed. Please check the backend and AiServer status.';
 
 export function useAiChat(enabled: boolean) {
   const [messages, setMessages] = useState<ChatMessage[]>(() => [
@@ -20,56 +24,6 @@ export function useAiChat(enabled: boolean) {
   const [status, setStatus] = useState<'idle' | 'connecting' | 'streaming' | 'error'>('idle');
 
   const userIdRef = useRef<string>(generateUserId());
-  const eventSourceRef = useRef<EventSource | null>(null);
-  const currentAssistantMessageIdRef = useRef<string | null>(null);
-  const closingRef = useRef(false);
-
-  const closeSse = useCallback(() => {
-    closingRef.current = true;
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-      eventSourceRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => () => closeSse(), [closeSse]);
-
-  const appendAssistantChunk = useCallback((chunk: string) => {
-    if (aiServerApiRepository.isIgnorableChunk(chunk)) {
-      return;
-    }
-
-    setMessages((prev) => {
-      const currentId = currentAssistantMessageIdRef.current;
-      const lastMessage = prev[prev.length - 1];
-
-      if (
-        currentId != null &&
-        lastMessage?.role === 'assistant' &&
-        lastMessage.id === currentId
-      ) {
-        return [
-          ...prev.slice(0, -1),
-          { ...lastMessage, content: `${lastMessage.content}${chunk}` },
-        ];
-      }
-
-      const newMessage = createChatMessage('assistant', chunk);
-      currentAssistantMessageIdRef.current = newMessage.id;
-      return [...prev, newMessage];
-    });
-  }, []);
-
-  const finishStream = useCallback((finalChunk?: string) => {
-    if (finalChunk != null && !aiServerApiRepository.isIgnorableChunk(finalChunk)) {
-      appendAssistantChunk(finalChunk);
-    }
-
-    currentAssistantMessageIdRef.current = null;
-    setIsLoading(false);
-    setStatus('idle');
-    closeSse();
-  }, [appendAssistantChunk, closeSse]);
 
   const sendMessage = useCallback(async (content: string) => {
     const text = content.trim();
@@ -80,62 +34,27 @@ export function useAiChat(enabled: boolean) {
     setMessages((prev) => [...prev, createChatMessage('user', text)]);
     setIsLoading(true);
     setStatus('connecting');
-    currentAssistantMessageIdRef.current = null;
-
-    closeSse();
-    closingRef.current = false;
-
-    const eventSource = new EventSource(aiServerApiRepository.buildSseUrl(userIdRef.current));
-    eventSourceRef.current = eventSource;
-
-    eventSource.addEventListener('add', (event) => {
-      if (closingRef.current) {
-        return;
-      }
-      setStatus('streaming');
-      appendAssistantChunk(event.data ?? '');
-    });
-
-    eventSource.addEventListener('finish', (event) => {
-      if (closingRef.current) {
-        return;
-      }
-      finishStream(event.data ?? '');
-    });
-
-    eventSource.onerror = () => {
-      if (closingRef.current) {
-        return;
-      }
-
-      currentAssistantMessageIdRef.current = null;
-      setIsLoading(false);
-      setStatus('error');
-      closeSse();
-      setMessages((prev) => [...prev, createChatMessage('assistant', CONNECTION_ERROR_MESSAGE)]);
-    };
 
     try {
-      const response = await aiServerApiRepository.sendChatAi(userIdRef.current, text);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-    } catch {
-      currentAssistantMessageIdRef.current = null;
-      setIsLoading(false);
+      const response = await aiServerApiRepository.sendChatInput(userIdRef.current, text);
+      setMessages((prev) => [...prev, createChatMessage('assistant', response.reply)]);
+      setStatus('idle');
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message.trim() !== '' ? error.message : SEND_ERROR_MESSAGE;
+      setMessages((prev) => [...prev, createChatMessage('assistant', message)]);
       setStatus('error');
-      closeSse();
-      setMessages((prev) => [...prev, createChatMessage('assistant', SEND_ERROR_MESSAGE)]);
+    } finally {
+      setIsLoading(false);
     }
-  }, [appendAssistantChunk, closeSse, enabled, finishStream, isLoading]);
+  }, [enabled, isLoading]);
 
   const resetConversation = useCallback(() => {
-    closeSse();
-    currentAssistantMessageIdRef.current = null;
     setIsLoading(false);
     setStatus('idle');
     setMessages([createChatMessage('assistant', INITIAL_MESSAGE)]);
-  }, [closeSse]);
+    userIdRef.current = generateUserId();
+  }, []);
 
   return {
     enabled,

--- a/frontend/src/domain/constants/endpoints.ts
+++ b/frontend/src/domain/constants/endpoints.ts
@@ -11,4 +11,5 @@ export const ENDPOINTS = {
   FILE_HISTORY: 'file_history.do',
   FILE_PREVIEW: 'file_preview.do',
   MESSAGE_HISTORY_EVENTS: 'message_history_events.do',
+  CHAT_INPUT: 'chat_input.do',
 } as const;

--- a/frontend/src/infrastructure/api/AiServerApiRepository.ts
+++ b/frontend/src/infrastructure/api/AiServerApiRepository.ts
@@ -1,35 +1,36 @@
-const AI_SERVER_BASE_URL =
-  process.env.NEXT_PUBLIC_AISERVER_URL?.replace(/\/$/, '') ?? 'http://localhost:6060';
+import { ENDPOINTS } from '@/domain/constants/endpoints';
 
-const CONNECTED_EVENT_MESSAGE = '연결됨';
-const FINISH_EVENT_MESSAGE = '완료';
+type FrontendChatResponse = {
+  sessionId: string;
+  reply: string;
+};
 
-const buildAiServerUrl = (path: string): string => {
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  return `${AI_SERVER_BASE_URL}${normalizedPath}`;
+const getBaseUrl = (): string =>
+  typeof window === 'undefined' ? '' : process.env.NEXT_PUBLIC_API_URL ?? '';
+
+const buildUrl = (path: string): string => {
+  const base = getBaseUrl();
+  if (base) return `${base.replace(/\/$/, '')}/${path}`;
+  return `/api/proxy/${path}`;
 };
 
 export const aiServerApiRepository = {
-  buildSseUrl(userId: string): string {
-    const params = new URLSearchParams({ userId });
-    return `${buildAiServerUrl('/sse/connect')}?${params.toString()}`;
-  },
-
-  async sendChatAi(currentUserName: string, message: string): Promise<Response> {
-    return fetch(buildAiServerUrl('/chat/ai'), {
+  async sendChatInput(sessionId: string, message: string): Promise<FrontendChatResponse> {
+    const res = await fetch(buildUrl(ENDPOINTS.CHAT_INPUT), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ currentUserName, message }),
+      body: JSON.stringify({ sessionId, message }),
     });
-  },
 
-  isIgnorableChunk(chunk: string): boolean {
-    const normalized = chunk.trim();
-    return (
-      normalized === '' ||
-      normalized.toLowerCase() === 'null' ||
-      normalized === CONNECTED_EVENT_MESSAGE ||
-      normalized === FINISH_EVENT_MESSAGE
-    );
+    const body = await res.json().catch(() => null);
+    if (!res.ok) {
+      const reply = typeof body?.reply === 'string' ? body.reply : res.statusText;
+      throw new Error(reply || 'The chat request failed.');
+    }
+
+    return {
+      sessionId: typeof body?.sessionId === 'string' ? body.sessionId : sessionId,
+      reply: typeof body?.reply === 'string' ? body.reply : '',
+    };
   },
 };

--- a/frontend/src/presentation/components/AiChatPanel.tsx
+++ b/frontend/src/presentation/components/AiChatPanel.tsx
@@ -8,10 +8,10 @@ type AiChatPanelProps = {
 };
 
 const statusText: Record<'idle' | 'connecting' | 'streaming' | 'error', string> = {
-  idle: '대기 중',
-  connecting: 'AiServer 연결 중',
-  streaming: '응답 스트리밍 중',
-  error: '연결 오류',
+  idle: 'Ready',
+  connecting: 'Creating reply',
+  streaming: 'Receiving reply',
+  error: 'Connection error',
 };
 
 export function AiChatPanel({ enabled }: AiChatPanelProps) {
@@ -36,9 +36,11 @@ export function AiChatPanel({ enabled }: AiChatPanelProps) {
     <section className="card stack ai-chat-panel">
       <div className="row" style={{ justifyContent: 'space-between' }}>
         <div className="stack" style={{ gap: 4 }}>
-          <strong>AiServer 대화</strong>
+          <strong>Unified Chat Input</strong>
           <span className="muted" style={{ fontSize: 13 }}>
-            시작 버튼을 누른 뒤 질문을 보내면 `http://localhost:6060`의 AiServer와 대화합니다.
+            This panel uses the same parser as Telegram. You can test normal chat and commands like
+            {' '}
+            <code>/god</code>, <code>/eng</code>, and <code>/search</code> here.
           </span>
         </div>
         <div className="row">
@@ -46,14 +48,14 @@ export function AiChatPanel({ enabled }: AiChatPanelProps) {
             {statusText[status]}
           </span>
           <button type="button" onClick={resetConversation} disabled={isLoading}>
-            초기화
+            Reset
           </button>
         </div>
       </div>
 
       {!enabled && (
         <p className="notice notice-warning">
-          위의 시작 버튼을 한 번 눌러야 AI 대화 입력창이 활성화됩니다.
+          Start the chat first. Once enabled, the frontend will follow the same input flow as Telegram.
         </p>
       )}
 
@@ -64,7 +66,7 @@ export function AiChatPanel({ enabled }: AiChatPanelProps) {
             className={`ai-chat-message ${message.role === 'user' ? 'ai-chat-message-user' : 'ai-chat-message-assistant'}`}
           >
             <div className="muted" style={{ fontSize: 12, marginBottom: 4 }}>
-              {message.role === 'user' ? '나' : 'AI'}
+              {message.role === 'user' ? 'You' : 'AI'}
             </div>
             <div style={{ whiteSpace: 'pre-wrap' }}>{message.content}</div>
           </div>
@@ -74,7 +76,7 @@ export function AiChatPanel({ enabled }: AiChatPanelProps) {
             <div className="muted" style={{ fontSize: 12, marginBottom: 4 }}>
               AI
             </div>
-            <div className="ai-chat-typing">응답을 작성하고 있습니다...</div>
+            <div className="ai-chat-typing">Creating a reply...</div>
           </div>
         )}
         <div ref={messagesEndRef} />
@@ -94,13 +96,13 @@ export function AiChatPanel({ enabled }: AiChatPanelProps) {
           disabled={!enabled || isLoading}
           placeholder={
             enabled
-              ? 'AiServer에 물어볼 내용을 입력하세요. Enter로 전송, Shift+Enter로 줄바꿈.'
-              : '먼저 위의 시작 버튼을 눌러 주세요.'
+              ? 'Try normal chat or commands like /god, /eng, and /search. Press Enter to send and Shift+Enter for a new line.'
+              : 'Start the chat to enable input.'
           }
           className="ai-chat-input"
         />
         <button type="button" onClick={handleSend} disabled={!enabled || isLoading || draft.trim() === ''}>
-          전송
+          Send
         </button>
       </div>
     </section>


### PR DESCRIPTION
## 요약
- 1:1과 그룹 채팅에서 일반 질문도 AI가 바로 응답하도록 흐름을 정리했습니다.
- 일반 문장의 첫 단어 때문에 `/eng`, `/god` 같은 모드로 잘못 전환되던 문제를 막았습니다.
- 한국어 질문에 대해 한국어 우선 응답이 되도록 AiServer 일반 답변 흐름을 보강했습니다.

## 변경 사항
- 그룹/1:1 일반 메시지를 AiServer 일반 응답 경로로 라우팅하도록 수정
- bare alias 명령은 메시지 전체가 정확히 일치할 때만 인식하도록 조정
- 의도치 않은 `/eng`, `/god` 모드 진입 방지
- 한국어 질문인데 영어 응답이 나오는 경우 한국어 fallback 처리 추가
- start/help 문구에 일반 질문도 AI가 응답한다는 안내 반영

## 기대 효과
- 사용자가 명령어를 입력하지 않아도 자연스럽게 질문하고 답을 받을 수 있습니다.
- 그룹 채팅과 1:1 채팅의 일반 대화 경험이 더 일관되게 동작합니다.
- 한국어 질문에 영어가 튀는 현상을 줄일 수 있습니다.

## 검증
- `backend`: `.\gradlew.bat test`
- `AiServer`: `.\gradlew.bat build -x test`
