### PR TITLE
fix: 답글 맥락 설명 흐름 개선 및 Redis 큐 timeout 안정화

### DIFF
--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/LocalOllamaCompletionService.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/LocalOllamaCompletionService.kt
@@ -11,7 +11,7 @@ class LocalOllamaCompletionService(
     @Value("\${spring.ai.ollama.base-url:http://localhost:11434}") baseUrl: String,
     @param:Value("\${spring.ai.ollama.chat.model:qwen2.5:7b-instruct}") private val model: String,
     @param:Value("\${spring.ai.ollama.chat.options.temperature:0.7}") private val temperature: Double,
-    @param:Value("\${spring.ai.ollama.chat.options.num_predict:1000}") private val numPredict: Int
+    @param:Value("\${spring.ai.ollama.chat.options.num_predict:256}") private val numPredict: Int
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/ModeAnswerService.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/ModeAnswerService.kt
@@ -70,13 +70,34 @@ class ModeAnswerService(
     }
 
     private fun generateResponse(mode: AssistantConversationMode, message: String, replyContext: String?): String {
+        val prompt = if (mode != AssistantConversationMode.ENG && !replyContext.isNullOrBlank() && isClarificationRequest(message)) {
+            Prompt(
+                """
+                You are helping a Korean user understand a previous assistant message from ${mode.modeName} mode.
+                The user is replying to that previous message and asking what it means.
+                Explain the previous message directly in plain Korean.
+                If the previous message contains Chinese, mixed language, or broken wording, rewrite its intended meaning in natural Korean.
+                Do not create a new quote or proverb in this case. Focus on explaining the replied message.
+                Reply only in Korean.
+
+                Previous message:
+                $replyContext
+
+                User follow-up:
+                $message
+                """.trimIndent()
+            )
+        } else {
+            mode.toPrompt(message, replyContext)
+        }
+
         val chatClient = chatClientProvider.ifAvailable
         if (chatClient != null) {
-            return chatClient.prompt(mode.toPrompt(message, replyContext)).call().content()?.trim().orEmpty()
+            return chatClient.prompt(prompt).call().content()?.trim().orEmpty()
         }
 
         logger.warn("No ChatClient bean is configured for mode chat. Trying local Ollama generate API. mode={}", mode.modeName)
-        val ollamaResponse = localOllamaCompletionService.generate(mode.toPrompt(message, replyContext).contents)
+        val ollamaResponse = localOllamaCompletionService.generate(prompt.contents)
         if (ollamaResponse.isNotBlank()) {
             return ollamaResponse
         }
@@ -123,6 +144,27 @@ class ModeAnswerService(
     private fun containsHangul(text: String): Boolean =
         text.any { ch -> ch in '\uAC00'..'\uD7A3' || ch in '\u3131'..'\u318E' }
 
+    private fun isClarificationRequest(message: String): Boolean {
+        val normalized = message.lowercase()
+        return listOf(
+            "무슨말",
+            "무슨 말",
+            "뭔말",
+            "무슨뜻",
+            "무슨 뜻",
+            "설명해",
+            "설명 좀",
+            "쉽게 말",
+            "쉽게 설명",
+            "다시 말",
+            "다시 설명",
+            "번역해",
+            "이게 뭐",
+            "이건 뭐",
+            "무슨 이야기"
+        ).any { normalized.contains(it) }
+    }
+
     private enum class AssistantConversationMode(
         val modeName: String,
         val emptyMessage: String,
@@ -151,6 +193,7 @@ class ModeAnswerService(
                 Start with one short quote, proverb, or wisdom sentence.
                 After that, add one or two short lines that connect the quote to the user's message.
                 Keep it gentle, concise, and uplifting.
+                If the user is replying to a previous message and asking what it means, explain that previous message directly instead of giving a new quote.
 
                 User message:
                 {replyContext}{message}
@@ -176,7 +219,7 @@ class ModeAnswerService(
 
             private fun replyContextSection(replyContext: String?): String =
                 replyContext?.trim()?.takeIf { it.isNotBlank() }
-                    ?.let { "The user is replying to this previous message:\n$it\n\n" }
+                    ?.let { "Previous replied message:\n$it\n\n" }
                     .orEmpty()
 
             private fun buildFallbackEnglishReply(message: String): String {
@@ -196,7 +239,7 @@ class ModeAnswerService(
             private fun buildFallbackGodReply(message: String): String {
                 val quotes = listOf(
                     "작은 걸음도 멈추지 않으면 결국 길이 됩니다.",
-                    "비 온 뒤에 땅이 굳듯, 어려운 날 뒤에도 단단함이 남습니다.",
+                    "비가 온 뒤에 땅이 굳듯, 어려움 뒤에는 단단함이 남습니다.",
                     "오늘의 버팀이 내일의 힘이 됩니다.",
                     "천천히 가도 멈추지 않으면 앞으로 갑니다."
                 )

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/ModeAnswerService.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/ModeAnswerService.kt
@@ -24,7 +24,7 @@ class ModeAnswerService(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun answer(currentUserName: String, message: String, mode: String): String {
+    fun answer(currentUserName: String, message: String, mode: String, replyContext: String? = null): String {
         val conversationMode = AssistantConversationMode.from(mode)
             ?: return UNSUPPORTED_MODE_MESSAGE
 
@@ -41,7 +41,7 @@ class ModeAnswerService(
         var answer = ""
         val ran = redisLockPort.withLock("chat:$currentUserName", 30L) {
             answer = try {
-                generateResponse(conversationMode, normalizedMessage)
+                generateResponse(conversationMode, normalizedMessage, replyContext)
                     .ifBlank { conversationMode.fallbackReply(normalizedMessage) }
             } catch (error: Exception) {
                 logger.error(
@@ -63,19 +63,20 @@ class ModeAnswerService(
             answer = conversationMode.fallbackReply(normalizedMessage)
         }
 
+        answer = ensureModeLanguage(conversationMode, normalizedMessage, answer)
         domainEventPublisher.publish(ChatResponseGenerated(currentUserName, answer.length, conversationMode.modeName))
         redisQueuePort.pushChatSaveJob(currentUserName, normalizedMessage, answer, conversationMode.modeName)
         return answer
     }
 
-    private fun generateResponse(mode: AssistantConversationMode, message: String): String {
+    private fun generateResponse(mode: AssistantConversationMode, message: String, replyContext: String?): String {
         val chatClient = chatClientProvider.ifAvailable
         if (chatClient != null) {
-            return chatClient.prompt(mode.toPrompt(message)).call().content()?.trim().orEmpty()
+            return chatClient.prompt(mode.toPrompt(message, replyContext)).call().content()?.trim().orEmpty()
         }
 
         logger.warn("No ChatClient bean is configured for mode chat. Trying local Ollama generate API. mode={}", mode.modeName)
-        val ollamaResponse = localOllamaCompletionService.generate(mode.toPrompt(message).contents)
+        val ollamaResponse = localOllamaCompletionService.generate(mode.toPrompt(message, replyContext).contents)
         if (ollamaResponse.isNotBlank()) {
             return ollamaResponse
         }
@@ -83,6 +84,44 @@ class ModeAnswerService(
         logger.warn("Local Ollama generate API was unavailable. Falling back to template response. mode={}", mode.modeName)
         return mode.fallbackReply(message)
     }
+
+    private fun ensureModeLanguage(mode: AssistantConversationMode, message: String, rawReply: String): String {
+        val trimmed = rawReply.trim()
+        if (trimmed.isBlank()) {
+            return mode.fallbackReply(message)
+        }
+        if (mode == AssistantConversationMode.ENG) {
+            return trimmed
+        }
+        if (containsHangul(trimmed)) {
+            return trimmed
+        }
+
+        logger.warn("Non-Korean mode reply detected. Rewriting to Korean. mode={}", mode.modeName)
+        val rewritten = localOllamaCompletionService.generate(
+            """
+            Rewrite the following assistant reply in natural Korean.
+            Reply only in Korean.
+            Do not use Chinese.
+            Preserve the original meaning and keep it concise.
+
+            User message:
+            $message
+
+            Assistant draft:
+            $trimmed
+            """.trimIndent()
+        ).trim()
+
+        return if (rewritten.isNotBlank() && containsHangul(rewritten)) {
+            rewritten
+        } else {
+            mode.fallbackReply(message)
+        }
+    }
+
+    private fun containsHangul(text: String): Boolean =
+        text.any { ch -> ch in '\uAC00'..'\uD7A3' || ch in '\u3131'..'\u318E' }
 
     private enum class AssistantConversationMode(
         val modeName: String,
@@ -99,26 +138,31 @@ class ModeAnswerService(
                 If the user writes in Korean, still answer in English.
 
                 User message:
-                {message}
+                {replyContext}{message}
             """.trimIndent()
         ),
         GOD(
             modeName = "god",
-            emptyMessage = "명언 느낌으로 답할 주제를 입력해 주세요.",
+            emptyMessage = "명언 모드로 대화할 내용을 입력해 주세요.",
             promptTemplate = """
-                You are a warm inspirational assistant.
-                Reply in Korean.
+                You are a warm inspirational assistant for a Korean user.
+                Reply only in natural Korean.
+                Never answer in Chinese.
                 Start with one short quote, proverb, or wisdom sentence.
                 After that, add one or two short lines that connect the quote to the user's message.
                 Keep it gentle, concise, and uplifting.
 
                 User message:
-                {message}
+                {replyContext}{message}
             """.trimIndent()
         );
 
-        fun toPrompt(message: String): Prompt =
-            Prompt(promptTemplate.replace("{message}", message))
+        fun toPrompt(message: String, replyContext: String?): Prompt =
+            Prompt(
+                promptTemplate
+                    .replace("{replyContext}", replyContextSection(replyContext))
+                    .replace("{message}", message)
+            )
 
         fun fallbackReply(message: String): String =
             when (this) {
@@ -130,25 +174,30 @@ class ModeAnswerService(
             fun from(mode: String): AssistantConversationMode? =
                 entries.find { it.modeName.equals(mode.trim(), ignoreCase = true) }
 
+            private fun replyContextSection(replyContext: String?): String =
+                replyContext?.trim()?.takeIf { it.isNotBlank() }
+                    ?.let { "The user is replying to this previous message:\n$it\n\n" }
+                    .orEmpty()
+
             private fun buildFallbackEnglishReply(message: String): String {
                 val normalized = message.trim()
                 return when {
                     normalized.endsWith("?") ->
-                        "That's a thoughtful question. My short answer is to take it step by step and keep moving forward."
+                        "That is a thoughtful question. Let us work through it step by step."
 
                     normalized.length <= 12 ->
                         "I hear you. Tell me a little more, and I will keep replying in English."
 
                     else ->
-                        "Thanks for sharing. Let's keep talking in English, one step at a time."
+                        "Thanks for sharing. Let us keep talking in English, one step at a time."
                 }
             }
 
             private fun buildFallbackGodReply(message: String): String {
                 val quotes = listOf(
                     "작은 걸음도 멈추지 않으면 결국 길이 됩니다.",
-                    "비 온 뒤에 땅이 굳듯, 어려움 뒤에는 단단함이 남습니다.",
-                    "오늘의 인내가 내일의 힘이 됩니다.",
+                    "비 온 뒤에 땅이 굳듯, 어려운 날 뒤에도 단단함이 남습니다.",
+                    "오늘의 버팀이 내일의 힘이 됩니다.",
                     "천천히 가도 멈추지 않으면 앞으로 갑니다."
                 )
                 val quote = quotes[(message.hashCode() and Int.MAX_VALUE) % quotes.size]

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/RagAnswerService.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/RagAnswerService.kt
@@ -23,7 +23,8 @@ class RagAnswerService(
         currentUserName: String,
         question: String,
         useKnowledgeBase: Boolean = true,
-        strictKnowledgeBase: Boolean = false
+        strictKnowledgeBase: Boolean = false,
+        replyContext: String? = null
     ): String {
         val normalizedQuestion = question.trim()
         if (normalizedQuestion.isBlank()) {
@@ -50,30 +51,26 @@ class RagAnswerService(
         }
 
         val prompt = if (searchResults.isNotEmpty()) {
-            createRagPrompt(normalizedQuestion, searchResults)
+            createRagPrompt(normalizedQuestion, searchResults, replyContext)
         } else if (!useKnowledgeBase) {
-            createGeneralPrompt(normalizedQuestion)
+            createGeneralPrompt(normalizedQuestion, replyContext)
         } else {
             Prompt(normalizedQuestion)
         }
 
         val content = generateResponse(prompt, searchResults)
         if (content.isNotBlank()) {
-            if (shouldPreferKorean(normalizedQuestion) && looksEnglishOnly(content)) {
-                logger.warn("General answer language mismatch detected. Falling back to Korean reply.")
-                return buildKoreanFallback(normalizedQuestion)
-            }
-            return content
+            return ensureKoreanReply(normalizedQuestion, content)
         }
 
         return if (strictKnowledgeBase && useKnowledgeBase) {
             NO_MATCH_MESSAGE
         } else {
-            "답변을 생성하지 못했습니다."
+            buildKoreanFallback(normalizedQuestion)
         }
     }
 
-    private fun createRagPrompt(question: String, searchResults: List<Document>): Prompt {
+    private fun createRagPrompt(question: String, searchResults: List<Document>, replyContext: String?): Prompt {
         val context = searchResults.joinToString("\n---\n") { doc ->
             val fileName = doc.metadata["fileName"] ?: "이름 없는 문서"
             "[$fileName]\n${doc.text.orEmpty()}"
@@ -81,16 +78,23 @@ class RagAnswerService(
 
         val promptContent = RAG_PROMPT_TEMPLATE
             .replace("{context}", context)
+            .replace("{replyContext}", replyContextSection(replyContext))
             .replace("{question}", question)
 
         return Prompt(promptContent)
     }
 
-    private fun createGeneralPrompt(question: String): Prompt {
+    private fun createGeneralPrompt(question: String, replyContext: String?): Prompt {
         val promptContent = GENERAL_PROMPT_TEMPLATE
+            .replace("{replyContext}", replyContextSection(replyContext))
             .replace("{question}", question)
         return Prompt(promptContent)
     }
+
+    private fun replyContextSection(replyContext: String?): String =
+        replyContext?.trim()?.takeIf { it.isNotBlank() }
+            ?.let { "The user is replying to this previous message:\n$it\n\n" }
+            .orEmpty()
 
     private fun generateResponse(prompt: Prompt, searchResults: List<Document>): String {
         val chatClient = chatClientProvider.ifAvailable
@@ -121,49 +125,82 @@ class RagAnswerService(
         }.trim()
     }
 
-    private fun shouldPreferKorean(question: String): Boolean =
-        question.any { ch -> ch in '\uAC00'..'\uD7A3' || ch in '\u3131'..'\u318E' }
+    private fun ensureKoreanReply(question: String, rawReply: String): String {
+        val trimmed = rawReply.trim()
+        if (trimmed.isBlank()) {
+            return buildKoreanFallback(question)
+        }
+        if (containsHangul(trimmed)) {
+            return trimmed
+        }
 
-    private fun looksEnglishOnly(content: String): Boolean {
-        val hasHangul = content.any { ch -> ch in '\uAC00'..'\uD7A3' || ch in '\u3131'..'\u318E' }
-        val hasLatin = content.any { it in 'A'..'Z' || it in 'a'..'z' }
-        return hasLatin && !hasHangul
+        logger.warn("Non-Korean general reply detected. Rewriting to Korean.")
+        val rewritten = localOllamaCompletionService.generate(
+            """
+            Rewrite the following assistant reply in natural Korean.
+            Reply only in Korean.
+            Do not use Chinese.
+            Preserve the original meaning and keep it concise.
+
+            User question:
+            $question
+
+            Assistant draft:
+            $trimmed
+            """.trimIndent()
+        ).trim()
+
+        return when {
+            rewritten.isBlank() -> buildKoreanFallback(question)
+            containsHangul(rewritten) -> rewritten
+            else -> buildKoreanFallback(question)
+        }
     }
 
     private fun buildKoreanFallback(question: String): String =
         when {
-            question.endsWith("?") || question.contains("왜") || question.contains("어떻게") ->
-                "좋은 질문이에요. 핵심부터 차근차근 같이 풀어볼게요."
+            question.contains("코드") || question.contains("버그") || question.contains("에러") ->
+                "코드 관련해서 도와드릴 수 있어요. 에러 메시지나 원하는 동작을 한 줄만 더 알려 주세요."
+
+            question.contains("배고프") ->
+                "배고프시군요. 지금 바로 먹을 수 있는 것부터 먼저 챙겨 보세요. 원하면 간단한 메뉴도 같이 골라드릴게요."
 
             question.contains("힘들") || question.contains("외롭") || question.contains("슬프") ->
                 "많이 버거우셨겠어요. 지금 가장 크게 걸리는 부분부터 편하게 말해 주세요."
+
+            question.endsWith("?") || question.contains("왜") || question.contains("어떻게") || question.contains("뭐") ->
+                "좋은 질문이에요. 핵심부터 차근차근 같이 풀어볼게요."
 
             else ->
                 "계속 말씀해 주세요. 질문하신 내용에 맞춰 이어서 도와드릴게요."
         }
 
+    private fun containsHangul(text: String): Boolean =
+        text.any { ch -> ch in '\uAC00'..'\uD7A3' || ch in '\u3131'..'\u318E' }
+
     companion object {
         private const val GENERAL_PROMPT_TEMPLATE = """
-        You are a helpful chat assistant.
-        Default to Korean unless the user clearly writes mostly in English or explicitly asks for English.
-        If the user writes in Korean, answer only in Korean.
-        Do not switch to English just because a few English words appear in the message.
+        You are a helpful assistant for a Korean user.
+        Always answer in natural Korean.
+        Never answer in Chinese.
+        Do not switch to English unless the user explicitly asks for English mode.
         Keep the reply concise, direct, and conversational.
 
         User message:
-        {question}
+        {replyContext}{question}
         """
 
         private const val RAG_PROMPT_TEMPLATE = """
         아래 참고 자료를 우선 사용해서 사용자 질문에 답하세요.
         참고 자료에 없는 내용은 추측하지 말고, 문서에서 찾지 못했다고 명확히 말하세요.
-        답변 언어는 사용자의 질문 언어를 따르세요. 한국어 질문이면 한국어로만 답하세요.
+        답변은 반드시 자연스러운 한국어로만 작성하세요.
+        중국어로 답하지 마세요.
 
         참고 자료:
         {context}
 
         사용자 질문:
-        {question}
+        {replyContext}{question}
         """
 
         private const val NO_DOCUMENTS_MESSAGE =

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/RagAnswerService.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/aplication/service/RagAnswerService.kt
@@ -50,23 +50,22 @@ class RagAnswerService(
             }
         }
 
-        val prompt = if (searchResults.isNotEmpty()) {
-            createRagPrompt(normalizedQuestion, searchResults, replyContext)
-        } else if (!useKnowledgeBase) {
-            createGeneralPrompt(normalizedQuestion, replyContext)
-        } else {
-            Prompt(normalizedQuestion)
+        val prompt = when {
+            searchResults.isNotEmpty() -> createRagPrompt(normalizedQuestion, searchResults, replyContext)
+            !replyContext.isNullOrBlank() && isClarificationRequest(normalizedQuestion) ->
+                createClarificationPrompt(normalizedQuestion, replyContext)
+            else -> createGeneralPrompt(normalizedQuestion, replyContext)
         }
 
         val content = generateResponse(prompt, searchResults)
         if (content.isNotBlank()) {
-            return ensureKoreanReply(normalizedQuestion, content)
+            return ensureKoreanReply(normalizedQuestion, content, replyContext)
         }
 
         return if (strictKnowledgeBase && useKnowledgeBase) {
             NO_MATCH_MESSAGE
         } else {
-            buildKoreanFallback(normalizedQuestion)
+            buildKoreanFallback(normalizedQuestion, replyContext)
         }
     }
 
@@ -91,9 +90,28 @@ class RagAnswerService(
         return Prompt(promptContent)
     }
 
+    private fun createClarificationPrompt(question: String, replyContext: String): Prompt =
+        Prompt(
+            """
+            You are helping a Korean user understand a previous assistant message.
+            The user replied to that previous message and is asking what it means.
+            Explain the previous message directly in plain Korean.
+            If the previous message contains Chinese, mixed language, or broken wording, rewrite its intended meaning in natural Korean.
+            Do not answer generically. Focus on the previous message first.
+            Keep the explanation concise but specific.
+            Reply only in Korean.
+
+            Previous message:
+            $replyContext
+
+            User follow-up:
+            $question
+            """.trimIndent()
+        )
+
     private fun replyContextSection(replyContext: String?): String =
         replyContext?.trim()?.takeIf { it.isNotBlank() }
-            ?.let { "The user is replying to this previous message:\n$it\n\n" }
+            ?.let { "Previous replied message:\n$it\n\n" }
             .orEmpty()
 
     private fun generateResponse(prompt: Prompt, searchResults: List<Document>): String {
@@ -125,10 +143,10 @@ class RagAnswerService(
         }.trim()
     }
 
-    private fun ensureKoreanReply(question: String, rawReply: String): String {
+    private fun ensureKoreanReply(question: String, rawReply: String, replyContext: String?): String {
         val trimmed = rawReply.trim()
         if (trimmed.isBlank()) {
-            return buildKoreanFallback(question)
+            return buildKoreanFallback(question, replyContext)
         }
         if (containsHangul(trimmed)) {
             return trimmed
@@ -142,6 +160,9 @@ class RagAnswerService(
             Do not use Chinese.
             Preserve the original meaning and keep it concise.
 
+            Previous message:
+            ${replyContext ?: "(none)"}
+
             User question:
             $question
 
@@ -151,21 +172,24 @@ class RagAnswerService(
         ).trim()
 
         return when {
-            rewritten.isBlank() -> buildKoreanFallback(question)
+            rewritten.isBlank() -> buildKoreanFallback(question, replyContext)
             containsHangul(rewritten) -> rewritten
-            else -> buildKoreanFallback(question)
+            else -> buildKoreanFallback(question, replyContext)
         }
     }
 
-    private fun buildKoreanFallback(question: String): String =
+    private fun buildKoreanFallback(question: String, replyContext: String? = null): String =
         when {
+            !replyContext.isNullOrBlank() && isClarificationRequest(question) ->
+                "방금 답변의 뜻을 다시 쉽게 풀어드릴게요. 직전에 답글로 단 문장을 기준으로 설명해야 하는 상황으로 이해했어요. 특히 헷갈린 표현을 한 문장만 더 짚어 주시면 그 부분부터 정확히 설명할게요."
+
             question.contains("코드") || question.contains("버그") || question.contains("에러") ->
-                "코드 관련해서 도와드릴 수 있어요. 에러 메시지나 원하는 동작을 한 줄만 더 알려 주세요."
+                "코드 관련해서 도와드릴 수 있어요. 에러 메시지나 기대한 동작을 한두 줄만 더 알려 주세요."
 
-            question.contains("배고프") ->
-                "배고프시군요. 지금 바로 먹을 수 있는 것부터 먼저 챙겨 보세요. 원하면 간단한 메뉴도 같이 골라드릴게요."
+            question.contains("배고파") ->
+                "배고프시군요. 지금 바로 먹을 수 있는 것부터 먼저 챙겨 보세요. 원하시면 간단한 메뉴도 같이 골라드릴게요."
 
-            question.contains("힘들") || question.contains("외롭") || question.contains("슬프") ->
+            question.contains("힘들") || question.contains("우울") || question.contains("슬프") ->
                 "많이 버거우셨겠어요. 지금 가장 크게 걸리는 부분부터 편하게 말해 주세요."
 
             question.endsWith("?") || question.contains("왜") || question.contains("어떻게") || question.contains("뭐") ->
@@ -174,6 +198,27 @@ class RagAnswerService(
             else ->
                 "계속 말씀해 주세요. 질문하신 내용에 맞춰 이어서 도와드릴게요."
         }
+
+    private fun isClarificationRequest(question: String): Boolean {
+        val normalized = question.lowercase()
+        return listOf(
+            "무슨말",
+            "무슨 말",
+            "뭔말",
+            "무슨뜻",
+            "무슨 뜻",
+            "설명해",
+            "설명 좀",
+            "쉽게 말",
+            "쉽게 설명",
+            "다시 말",
+            "다시 설명",
+            "번역해",
+            "이게 뭐",
+            "이건 뭐",
+            "무슨 이야기"
+        ).any { normalized.contains(it) }
+    }
 
     private fun containsHangul(text: String): Boolean =
         text.any { ch -> ch in '\uAC00'..'\uD7A3' || ch in '\u3131'..'\u318E' }
@@ -185,16 +230,19 @@ class RagAnswerService(
         Never answer in Chinese.
         Do not switch to English unless the user explicitly asks for English mode.
         Keep the reply concise, direct, and conversational.
+        If the user is replying to a previous message, use that previous message as the primary context.
+        If the user asks what the previous message means, explain that previous message directly in Korean instead of giving a generic answer.
 
         User message:
         {replyContext}{question}
         """
 
         private const val RAG_PROMPT_TEMPLATE = """
-        아래 참고 자료를 우선 사용해서 사용자 질문에 답하세요.
-        참고 자료에 없는 내용은 추측하지 말고, 문서에서 찾지 못했다고 명확히 말하세요.
-        답변은 반드시 자연스러운 한국어로만 작성하세요.
+        아래 참고 자료를 우선 사용해서 사용자의 질문에 답하세요.
+        참고 자료에 없는 내용은 추측하지 말고, 문서에서 찾지 못했다고 분명하게 말하세요.
+        답변은 반드시 자연스럽고 이해하기 쉬운 한국어로만 작성하세요.
         중국어로 답하지 마세요.
+        사용자가 이전 메시지에 대한 뜻을 묻는 경우에는 그 메시지를 먼저 풀어서 설명하세요.
 
         참고 자료:
         {context}

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/infrastructure/redis/RedisQueueAdapter.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/infrastructure/redis/RedisQueueAdapter.kt
@@ -3,26 +3,36 @@ package com.sleekydz86.tellme.aiserver.infrastructure.redis
 import com.sleekydz86.tellme.aiserver.aplication.port.ChatSaveJob
 import com.sleekydz86.tellme.aiserver.aplication.port.PendingQuestion
 import com.sleekydz86.tellme.aiserver.aplication.port.RedisQueuePort
+import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicLong
 
 @Component
 class RedisQueueAdapter(
     private val redisTemplate: RedisTemplate<String, Any>
 ) : RedisQueuePort {
 
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val lastFailureLogAt = AtomicLong(0L)
+
     companion object {
         private const val QUEUE_CHAT_SAVE = "queue:chat:save"
         private const val QUEUE_PENDING_QUESTIONS = "queue:pending:questions"
+        private const val FAILURE_LOG_INTERVAL_MS = 30_000L
     }
 
     override fun pushChatSaveJob(userId: String, userMessage: String, assistantMessage: String, mode: String) {
-        redisTemplate.opsForList().rightPush(QUEUE_CHAT_SAVE, ChatSaveJob(userId, userMessage, assistantMessage, mode))
+        safeWrite("rightPush", QUEUE_CHAT_SAVE) {
+            redisTemplate.opsForList().rightPush(QUEUE_CHAT_SAVE, ChatSaveJob(userId, userMessage, assistantMessage, mode))
+        }
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun popChatSaveJob(): ChatSaveJob? {
-        val raw = redisTemplate.opsForList().leftPop(QUEUE_CHAT_SAVE) ?: return null
+        val raw = safeRead("leftPop", QUEUE_CHAT_SAVE) {
+            redisTemplate.opsForList().leftPop(QUEUE_CHAT_SAVE)
+        } ?: return null
         return mapToChatSaveJob(raw)
     }
 
@@ -33,12 +43,16 @@ class RedisQueueAdapter(
             "mode" to mode,
             "createdAt" to System.currentTimeMillis()
         )
-        redisTemplate.opsForList().rightPush(QUEUE_PENDING_QUESTIONS, payload)
+        safeWrite("rightPush", QUEUE_PENDING_QUESTIONS) {
+            redisTemplate.opsForList().rightPush(QUEUE_PENDING_QUESTIONS, payload)
+        }
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun rangePendingQuestions(start: Long, end: Long): List<PendingQuestion> {
-        val list = redisTemplate.opsForList().range(QUEUE_PENDING_QUESTIONS, start, end) ?: return emptyList()
+        val list = safeRead("range", QUEUE_PENDING_QUESTIONS) {
+            redisTemplate.opsForList().range(QUEUE_PENDING_QUESTIONS, start, end)
+        } ?: return emptyList()
         return list.mapNotNull { raw ->
             (raw as? Map<*, *>)?.let { m ->
                 PendingQuestion(
@@ -53,7 +67,9 @@ class RedisQueueAdapter(
 
     @Suppress("UNCHECKED_CAST")
     override fun popPendingQuestion(): PendingQuestion? {
-        val raw = redisTemplate.opsForList().leftPop(QUEUE_PENDING_QUESTIONS) ?: return null
+        val raw = safeRead("leftPop", QUEUE_PENDING_QUESTIONS) {
+            redisTemplate.opsForList().leftPop(QUEUE_PENDING_QUESTIONS)
+        } ?: return null
         return (raw as? Map<*, *>)?.let { m ->
             PendingQuestion(
                 userId = m["userId"] as? String ?: "",
@@ -72,5 +88,43 @@ class RedisQueueAdapter(
             mode = m["mode"] as? String ?: "",
             createdAt = (m["createdAt"] as? Number)?.toLong() ?: System.currentTimeMillis()
         )
+    }
+
+    private fun safeWrite(action: String, queue: String, operation: () -> Unit) {
+        try {
+            operation()
+        } catch (error: Exception) {
+            logQueueFailure(action, queue, error)
+        }
+    }
+
+    private fun <T> safeRead(action: String, queue: String, operation: () -> T?): T? =
+        try {
+            operation()
+        } catch (error: Exception) {
+            logQueueFailure(action, queue, error)
+            null
+        }
+
+    private fun logQueueFailure(action: String, queue: String, error: Exception) {
+        val now = System.currentTimeMillis()
+        val lastLoggedAt = lastFailureLogAt.get()
+        val shouldWarn = now - lastLoggedAt >= FAILURE_LOG_INTERVAL_MS && lastFailureLogAt.compareAndSet(lastLoggedAt, now)
+        if (shouldWarn) {
+            logger.warn(
+                "Redis queue operation failed: action={}, queue={}, error={}. Queue processing will retry later.",
+                action,
+                queue,
+                error.message,
+                error
+            )
+        } else {
+            logger.debug(
+                "Redis queue operation failed: action={}, queue={}, error={}",
+                action,
+                queue,
+                error.message
+            )
+        }
     }
 }

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/presentation/controller/ChatController.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/presentation/controller/ChatController.kt
@@ -40,7 +40,8 @@ class ChatController(
             currentUserName = body.currentUserName,
             question = body.message,
             useKnowledgeBase = true,
-            strictKnowledgeBase = true
+            strictKnowledgeBase = true,
+            replyContext = body.replyContext
         )
     }
 
@@ -50,7 +51,8 @@ class ChatController(
             currentUserName = body.currentUserName,
             question = body.message,
             useKnowledgeBase = body.useKnowledgeBase,
-            strictKnowledgeBase = false
+            strictKnowledgeBase = false,
+            replyContext = body.replyContext
         )
     }
 
@@ -59,7 +61,8 @@ class ChatController(
         return modeAnswerService.answer(
             currentUserName = body.currentUserName,
             message = body.message,
-            mode = body.mode
+            mode = body.mode,
+            replyContext = body.replyContext
         )
     }
 }

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/presentation/dto/request/ChatSendRequest.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/presentation/dto/request/ChatSendRequest.kt
@@ -3,5 +3,6 @@ package com.sleekydz86.tellme.aiserver.presentation.dto.request
 data class ChatSendRequest(
     val currentUserName: String,
     val message: String,
-    val useKnowledgeBase: Boolean = false
+    val useKnowledgeBase: Boolean = false,
+    val replyContext: String? = null
 )

--- a/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/presentation/dto/request/ModeChatRequest.kt
+++ b/AiServer/src/main/kotlin/com/sleekydz86/tellme/aiserver/presentation/dto/request/ModeChatRequest.kt
@@ -3,5 +3,6 @@ package com.sleekydz86.tellme.aiserver.presentation.dto.request
 data class ModeChatRequest(
     val currentUserName: String,
     val message: String,
-    val mode: String
+    val mode: String,
+    val replyContext: String? = null
 )

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/global/config/AiServerProperties.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/global/config/AiServerProperties.kt
@@ -5,4 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "ai-server")
 class AiServerProperties {
     var url: String = "http://localhost:6060"
+    var responseTimeoutSeconds: Long = 45
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/port/AiServerModeChatPort.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/port/AiServerModeChatPort.kt
@@ -4,5 +4,5 @@ import com.sleekydz86.tellme.showme.domain.ConversationMode
 import reactor.core.publisher.Mono
 
 interface AiServerModeChatPort {
-    fun chat(userId: String, message: String, mode: ConversationMode): Mono<String>
+    fun chat(userId: String, message: String, mode: ConversationMode, replyContext: String? = null): Mono<String>
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/port/AiServerReplyPort.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/port/AiServerReplyPort.kt
@@ -3,5 +3,5 @@ package com.sleekydz86.tellme.showme.application.port
 import reactor.core.publisher.Mono
 
 interface AiServerReplyPort {
-    fun reply(userId: String, message: String): Mono<String>
+    fun reply(userId: String, message: String, replyContext: String? = null): Mono<String>
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
@@ -173,10 +173,10 @@ class HandleUpdateService(
                 text
             )
             return aiServerReply.reply(chatId.toString(), text, replyContext)
-                .timeout(PRIVATE_CHAT_REPLY_TIMEOUT, Mono.just(privateChatReplyFallbackFactory.build(text)))
+                .timeout(PRIVATE_CHAT_REPLY_TIMEOUT, Mono.just(privateChatReplyFallbackFactory.build(text, replyContext)))
                 .onErrorResume { e ->
                     log.warn("General chat fallback activated: chatId={}, chatType={}, source={}", chatId, ctx.chatType, ctx.inputSource, e)
-                    Mono.just(privateChatReplyFallbackFactory.build(text))
+                    Mono.just(privateChatReplyFallbackFactory.build(text, replyContext))
                 }
         }
 

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
@@ -163,14 +163,16 @@ class HandleUpdateService(
 
         if (activeMode == null) {
             val text = ctx.text.orEmpty()
+            val replyContext = ctx.replyContextSummary()
             log.info(
-                "Routing general chat text to AI reply: chatId={}, chatType={}, source={}, text={}",
+                "Routing general chat text to AI reply: chatId={}, chatType={}, source={}, hasReplyContext={}, text={}",
                 chatId,
                 ctx.chatType,
                 ctx.inputSource,
+                ctx.hasReplyContext(),
                 text
             )
-            return aiServerReply.reply(chatId.toString(), text)
+            return aiServerReply.reply(chatId.toString(), text, replyContext)
                 .timeout(PRIVATE_CHAT_REPLY_TIMEOUT, Mono.just(privateChatReplyFallbackFactory.build(text)))
                 .onErrorResume { e ->
                     log.warn("General chat fallback activated: chatId={}, chatType={}, source={}", chatId, ctx.chatType, ctx.inputSource, e)
@@ -179,13 +181,14 @@ class HandleUpdateService(
         }
 
         val text = ctx.text.orEmpty()
-        log.info("Routing text to active conversation mode: chatId={}, mode={}, text={}", chatId, activeMode.aiMode, text)
+        val replyContext = ctx.replyContextSummary()
+        log.info("Routing text to active conversation mode: chatId={}, mode={}, hasReplyContext={}, text={}", chatId, activeMode.aiMode, ctx.hasReplyContext(), text)
         if (isConversationExitText(text)) {
             conversationModeStore.clear(chatId)
             return Mono.just("${activeMode.label} ended. Returning to normal conversation.")
         }
 
-        return aiServerModeChat.chat(chatId.toString(), text, activeMode)
+        return aiServerModeChat.chat(chatId.toString(), text, activeMode, replyContext)
             .timeout(MODE_REPLY_TIMEOUT, Mono.just(fallbackReplyFactory.build(activeMode, text)))
             .onErrorResume { e ->
                 log.warn("Mode chat fallback activated: chatId={}, mode={}", chatId, activeMode.aiMode, e)

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/HandleUpdateService.kt
@@ -328,8 +328,8 @@ class HandleUpdateService(
 
     companion object {
         private const val EXIT_KEYWORD = "bye"
-        private val MODE_REPLY_TIMEOUT: Duration = Duration.ofSeconds(3)
-        private val PRIVATE_CHAT_REPLY_TIMEOUT: Duration = Duration.ofSeconds(8)
+        private val MODE_REPLY_TIMEOUT: Duration = Duration.ofSeconds(45)
+        private val PRIVATE_CHAT_REPLY_TIMEOUT: Duration = Duration.ofSeconds(45)
         private const val DEFAULT_REPLY_MESSAGE = "답변을 만드는 데 문제가 있었어요. 한 번만 다시 말씀해 주세요."
         private const val FALLBACK_MESSAGE = "텍스트나 파일(문서/사진/음성/동영상)을 보내 주세요."
     }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PrivateChatReplyFallbackFactory.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PrivateChatReplyFallbackFactory.kt
@@ -7,62 +7,24 @@ class PrivateChatReplyFallbackFactory {
 
     fun build(text: String): String {
         val normalized = text.trim()
-        return if (prefersEnglish(normalized)) {
-            buildEnglishReply(normalized)
-        } else {
-            buildKoreanReply(normalized)
-        }
-    }
+        return when {
+            normalized.isBlank() ->
+                "한 문장만 더 편하게 보내 주세요. 바로 이어서 도와드릴게요."
 
-    private fun buildKoreanReply(text: String): String =
-        when {
-            text.isBlank() ->
-                "마음에 걸리는 내용 한 문장만 더 말해 주세요. 바로 이어서 도와드릴게요."
+            normalized.contains("배고프") ->
+                "배고프시군요. 지금 바로 먹을 수 있는 게 있는지 먼저 챙겨 보세요. 원하면 간단한 메뉴도 같이 골라드릴게요."
 
-            text.contains("영어", ignoreCase = true) ->
-                "알겠어요. 이제 영어로 자연스럽게 이어서 대화할게요. 하고 싶은 말을 계속 보내 주세요."
+            normalized.contains("코드") || normalized.contains("버그") || normalized.contains("에러") ->
+                "코드 관련 질문이라면 언어, 에러 메시지, 원하는 동작 중 하나만 더 알려 주세요. 그럼 더 정확하게 도와드릴게요."
 
-            text.endsWith("?") ||
-                text.contains("왜") ||
-                text.contains("어떻게") ||
-                text.contains("뭐") ->
+            normalized.contains("힘들") || normalized.contains("지쳤") || normalized.contains("외롭") || normalized.contains("슬프") ->
+                "많이 버거우셨겠어요. 지금 가장 크게 걸리는 부분부터 편하게 말해 주세요."
+
+            normalized.endsWith("?") || normalized.contains("왜") || normalized.contains("어떻게") || normalized.contains("뭐") ->
                 "좋은 질문이에요. 핵심부터 차근차근 같이 풀어볼게요."
-
-            text.contains("힘들", ignoreCase = true) ||
-                text.contains("외롭", ignoreCase = true) ||
-                text.contains("슬프", ignoreCase = true) ||
-                text.contains("지쳤", ignoreCase = true) ||
-                text.contains("불안", ignoreCase = true) ->
-                "많이 버거우셨겠어요. 지금 제일 크게 걸리는 부분부터 편하게 말해 주세요."
 
             else ->
                 "계속 듣고 있어요. 더 이어서 말해 주시면 그 내용에 맞춰 바로 답할게요."
         }
-
-    private fun buildEnglishReply(text: String): String =
-        when {
-            text.isBlank() ->
-                "Tell me one more sentence about what is on your mind, and I will keep helping."
-
-            text.endsWith("?") ->
-                "That is a good question. Let us unpack it step by step."
-
-            text.contains("tired", ignoreCase = true) ||
-                text.contains("lonely", ignoreCase = true) ||
-                text.contains("hard", ignoreCase = true) ||
-                text.contains("sad", ignoreCase = true) ->
-                "That sounds heavy. Tell me the hardest part first, and I will stay with you."
-
-            else ->
-                "I am listening. Keep going and I will respond to what you say."
-        }
-
-    private fun prefersEnglish(text: String): Boolean {
-        if (text.contains("영어")) return true
-        if (containsHangul(text)) return false
-        return text.any { it in 'A'..'Z' || it in 'a'..'z' }
     }
-
-    private fun containsHangul(text: String): Boolean =
-        text.any { ch -> ch in '\uAC00'..'\uD7A3' || ch in '\u3131'..'\u318E' }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PrivateChatReplyFallbackFactory.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/application/service/PrivateChatReplyFallbackFactory.kt
@@ -5,19 +5,24 @@ import org.springframework.stereotype.Component
 @Component
 class PrivateChatReplyFallbackFactory {
 
-    fun build(text: String): String {
+    fun build(text: String, replyContext: String? = null): String {
         val normalized = text.trim()
+        val hasReplyContext = !replyContext.isNullOrBlank()
+
         return when {
             normalized.isBlank() ->
-                "한 문장만 더 편하게 보내 주세요. 바로 이어서 도와드릴게요."
+                "한 문장만 편하게 보내 주세요. 바로 이어서 도와드릴게요."
 
-            normalized.contains("배고프") ->
-                "배고프시군요. 지금 바로 먹을 수 있는 게 있는지 먼저 챙겨 보세요. 원하면 간단한 메뉴도 같이 골라드릴게요."
+            hasReplyContext && isClarificationRequest(normalized) ->
+                "방금 답장한 내용을 다시 쉽게 풀어드릴게요. 특히 헷갈린 문장을 한 번만 더 짚어 주시면 그 부분부터 정확히 설명할게요."
+
+            normalized.contains("배고파") ->
+                "배고프시군요. 지금 바로 먹을 수 있는 게 있는지부터 먼저 챙겨 보세요. 원하시면 간단한 메뉴도 같이 골라드릴게요."
 
             normalized.contains("코드") || normalized.contains("버그") || normalized.contains("에러") ->
-                "코드 관련 질문이라면 언어, 에러 메시지, 원하는 동작 중 하나만 더 알려 주세요. 그럼 더 정확하게 도와드릴게요."
+                "코드 관련 질문이라면 언어, 에러 메시지, 기대한 동작 중 하나만 더 알려 주세요. 그러면 더 정확하게 도와드릴게요."
 
-            normalized.contains("힘들") || normalized.contains("지쳤") || normalized.contains("외롭") || normalized.contains("슬프") ->
+            normalized.contains("힘들") || normalized.contains("지쳐") || normalized.contains("슬프") ->
                 "많이 버거우셨겠어요. 지금 가장 크게 걸리는 부분부터 편하게 말해 주세요."
 
             normalized.endsWith("?") || normalized.contains("왜") || normalized.contains("어떻게") || normalized.contains("뭐") ->
@@ -26,5 +31,26 @@ class PrivateChatReplyFallbackFactory {
             else ->
                 "계속 듣고 있어요. 더 이어서 말해 주시면 그 내용에 맞춰 바로 답할게요."
         }
+    }
+
+    private fun isClarificationRequest(text: String): Boolean {
+        val normalized = text.lowercase()
+        return listOf(
+            "무슨말",
+            "무슨 말",
+            "뭔말",
+            "무슨뜻",
+            "무슨 뜻",
+            "설명해",
+            "설명 좀",
+            "쉽게 말",
+            "쉽게 설명",
+            "다시 말",
+            "다시 설명",
+            "번역해",
+            "이게 뭐",
+            "이건 뭐",
+            "무슨 이야기"
+        ).any { normalized.contains(it) }
     }
 }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/MessageContext.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/MessageContext.kt
@@ -7,13 +7,24 @@ data class MessageContext(
     val text: String? = null,
     val firstName: String? = null,
     val chatType: String? = null,
-    val inputSource: InputSource = InputSource.TELEGRAM
+    val inputSource: InputSource = InputSource.TELEGRAM,
+    val replyToMessageId: Long? = null,
+    val replyToText: String? = null,
+    val replyToSenderName: String? = null
 ) {
     fun isPrivateChat(): Boolean = chatType.equals("private", ignoreCase = true)
 
     fun isFrontend(): Boolean = inputSource == InputSource.FRONTEND
 
     fun supportsAlarmSetup(): Boolean = inputSource.supportsAlarmSetup()
+
+    fun hasReplyContext(): Boolean = !replyToText.isNullOrBlank()
+
+    fun replyContextSummary(): String? {
+        val repliedText = replyToText?.trim()?.takeIf { it.isNotBlank() } ?: return null
+        val sender = replyToSenderName?.trim()?.takeIf { it.isNotBlank() } ?: "상대방"
+        return "$sender: $repliedText"
+    }
 
     fun commandArgument(): String? {
         val trimmed = text?.trim().orEmpty()
@@ -35,7 +46,10 @@ data class MessageContext(
                 text = message.text?.trim().orEmpty(),
                 firstName = message.from?.firstName ?: "User",
                 chatType = message.chat?.type,
-                inputSource = InputSource.TELEGRAM
+                inputSource = InputSource.TELEGRAM,
+                replyToMessageId = message.replyToMessage?.messageId,
+                replyToText = message.replyToMessage?.text?.trim(),
+                replyToSenderName = message.replyToMessage?.senderDisplayName()
             )
         }
     }

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/MessageContext.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/MessageContext.kt
@@ -22,8 +22,8 @@ data class MessageContext(
 
     fun replyContextSummary(): String? {
         val repliedText = replyToText?.trim()?.takeIf { it.isNotBlank() } ?: return null
-        val sender = replyToSenderName?.trim()?.takeIf { it.isNotBlank() } ?: "상대방"
-        return "$sender: $repliedText"
+        val sender = replyToSenderName?.trim()?.takeIf { it.isNotBlank() } ?: "previous_message"
+        return "reply_sender=$sender\nreply_text=$repliedText"
     }
 
     fun commandArgument(): String? {

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/dto/TelegramUpdate.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/domain/dto/TelegramUpdate.kt
@@ -57,6 +57,9 @@ class TelegramUpdate {
         @JsonProperty("text")
         val text: String? = null
 
+        @JsonProperty("reply_to_message")
+        val replyToMessage: Message? = null
+
         @JsonProperty("document")
         val document: Document? = null
 

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/adapter/AiServerWebClientAdapter.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/adapter/AiServerWebClientAdapter.kt
@@ -135,12 +135,13 @@ class AiServerWebClientAdapter(
             }
     }
 
-    override fun chat(userId: String, message: String, mode: ConversationMode): Mono<String> {
-        val body = mapOf(
+    override fun chat(userId: String, message: String, mode: ConversationMode, replyContext: String?): Mono<String> {
+        val body = linkedMapOf(
             "currentUserName" to userId,
             "message" to message,
             "mode" to mode.aiMode
         )
+        replyContext?.takeIf { it.isNotBlank() }?.let { body["replyContext"] = it }
         return webClient.post()
             .uri("/chat/mode")
             .contentType(MediaType.APPLICATION_JSON)
@@ -156,12 +157,13 @@ class AiServerWebClientAdapter(
             }
     }
 
-    override fun reply(userId: String, message: String): Mono<String> {
-        val body = mapOf(
+    override fun reply(userId: String, message: String, replyContext: String?): Mono<String> {
+        val body = linkedMapOf(
             "currentUserName" to userId,
             "message" to message,
             "useKnowledgeBase" to false
         )
+        replyContext?.takeIf { it.isNotBlank() }?.let { body["replyContext"] = it }
         return webClient.post()
             .uri("/chat/reply")
             .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/adapter/AiServerWebClientAdapter.kt
+++ b/backend/src/main/kotlin/com/sleekydz86/tellme/showme/infrastructure/adapter/AiServerWebClientAdapter.kt
@@ -1,5 +1,6 @@
 package com.sleekydz86.tellme.showme.infrastructure.adapter
 
+import com.sleekydz86.tellme.global.config.AiServerProperties
 import com.sleekydz86.tellme.showme.application.port.AiServerHistoryPort
 import com.sleekydz86.tellme.showme.application.port.AiServerModeChatPort
 import com.sleekydz86.tellme.showme.application.port.AiServerReplyPort
@@ -23,9 +24,11 @@ import java.time.Instant
 
 @Component
 class AiServerWebClientAdapter(
-    @Qualifier("aiServerWebClient") private val webClient: WebClient
+    @Qualifier("aiServerWebClient") private val webClient: WebClient,
+    aiServerProperties: AiServerProperties
 ) : AiServerUploadPort, AiServerTelegramPort, AiServerHistoryPort, AiServerSearchPort, AiServerModeChatPort, AiServerReplyPort {
     private val log = LoggerFactory.getLogger(AiServerWebClientAdapter::class.java)
+    private val aiServerResponseTimeout: Duration = Duration.ofSeconds(aiServerProperties.responseTimeoutSeconds)
 
     override fun upload(
         bytes: ByteArray,
@@ -123,7 +126,7 @@ class AiServerWebClientAdapter(
             .bodyValue(body)
             .retrieve()
             .bodyToMono(String::class.java)
-            .timeout(AI_SERVER_RESPONSE_TIMEOUT)
+            .timeout(aiServerResponseTimeout)
             .map { it.trim() }
             .defaultIfEmpty(EMPTY_SEARCH_RESULT_MESSAGE)
             .onErrorResume { e ->
@@ -144,7 +147,7 @@ class AiServerWebClientAdapter(
             .bodyValue(body)
             .retrieve()
             .bodyToMono(String::class.java)
-            .timeout(AI_SERVER_RESPONSE_TIMEOUT)
+            .timeout(aiServerResponseTimeout)
             .map { it.trim() }
             .filter { it.isNotBlank() }
             .switchIfEmpty(Mono.error(IllegalStateException("AiServer mode reply is blank: mode=${mode.aiMode}")))
@@ -165,7 +168,7 @@ class AiServerWebClientAdapter(
             .bodyValue(body)
             .retrieve()
             .bodyToMono(String::class.java)
-            .timeout(AI_SERVER_RESPONSE_TIMEOUT)
+            .timeout(aiServerResponseTimeout)
             .map { it.trim() }
             .filter { it.isNotBlank() }
             .switchIfEmpty(Mono.error(IllegalStateException("AiServer reply is blank")))
@@ -222,7 +225,6 @@ class AiServerWebClientAdapter(
     }
 
     companion object {
-        private val AI_SERVER_RESPONSE_TIMEOUT: Duration = Duration.ofSeconds(10)
         private const val EMPTY_SEARCH_RESULT_MESSAGE =
             "\uac80\uc0c9 \uacb0\uacfc\uac00 \ube44\uc5b4 \uc788\uc2b5\ub2c8\ub2e4."
         private const val SEARCH_ERROR_MESSAGE =


### PR DESCRIPTION
## 요약
- 텔레그램 답글형 질문이 일반적인 AI 응답으로 빠지지 않고, replied message를 직접 설명하도록 개선했습니다.
- AiServer Redis 큐 timeout으로 스케줄러 예외가 반복되던 문제를 완화했습니다.
- reply context fallback과 한국어 설명 흐름을 함께 보강했습니다.

## 변경 사항
- Telegram `reply_to_message` 문맥을 구조화된 형태로 backend에서 전달하도록 정리
- `무슨말이야`, `무슨 뜻이야`, `설명해줘`, `번역해` 같은 clarification 의도 감지 추가
- 일반 대화와 `/god` 모드 모두에서 답글형 질문을 이전 메시지 설명 전용 프롬프트로 분기
- 중국어/혼합 언어가 포함된 이전 메시지도 한국어로 다시 풀어 설명하도록 보강
- reply-context 질문이 generic fallback 응답으로 내려가지 않도록 backend fallback 개선
- Redis queue read/write 실패를 best-effort로 처리해 채팅 응답 흐름이 끊기지 않도록 수정
- AiServer Redis timeout을 `2000ms`에서 `${AI_SERVER_REDIS_TIMEOUT:5s}`로 상향

## 기대 효과
- 사용자가 봇 메시지에 답장으로 `무슨말이야` 같은 질문을 했을 때, 이전 메시지 의미를 직접 설명할 수 있습니다.
- 중국어가 섞인 답변이나 어색한 문장을 다시 한국어로 설명하는 흐름이 더 안정적입니다.
- Redis가 잠깐 느려도 스케줄러 예외가 계속 터지면서 사용자 응답 흐름을 망치지 않게 됩니다.

## 검증
- `backend`: `.\gradlew.bat test`
- `AiServer`: `.\gradlew.bat build -x test`
